### PR TITLE
feat: add material info to base game

### DIFF
--- a/page/factions/base/chaos/text.json
+++ b/page/factions/base/chaos/text.json
@@ -1,0 +1,10 @@
+{
+  "materialsText": [
+    { "label": "Cultists", "value": "7" },
+    { "label": "Iconoclast Destroyers", "value": "2" },
+    { "label": "Chaos Space Marines", "value": "4" },
+    { "label": "Helbrutes", "value": "3" },
+    { "label": "Repulsive Grand Cruisers", "value": "3" },
+    { "label": "Chaos Reaver Titans", "value": "3" }
+  ]
+}

--- a/page/factions/base/eldar/text.json
+++ b/page/factions/base/eldar/text.json
@@ -1,0 +1,10 @@
+{
+  "materialsText": [
+    { "label": "Aspect Warriors", "value": "3" },
+    { "label": "Hellebore Frigates", "value": "4" },
+    { "label": "Wraithguard", "value": "2" },
+    { "label": "Falcons", "value": "3" },
+    { "label": "Void Stalkers", "value": "3" }
+    { "label": "Warlock Battle Titans", "value": "3" }
+  ]
+}

--- a/page/factions/base/ork/text.json
+++ b/page/factions/base/ork/text.json
@@ -1,0 +1,10 @@
+{
+  "materialsText": [
+    { "label": "Ork Boyz", "value": "5" },
+    { "label": "Onslaught Attack Ships", "value": "3" },
+    { "label": "Nobz", "value": "5" },
+    { "label": "Battlewagons", "value": "3" },
+    { "label": "Kill Kroozers", "value": "3" },
+    { "label": "Gargants", "value": "3" }
+  ]
+}

--- a/page/factions/base/spacemarines/text.json
+++ b/page/factions/base/spacemarines/text.json
@@ -1,0 +1,10 @@
+{
+  "materialsText": [
+    { "label": "Scouts", "value": "2" },
+    { "label": "Strike Cruisers", "value": "2" },
+    { "label": "Space Marines", "value": "5" },
+    { "label": "Land Raiders", "value": "6" },
+    { "label": "Battle Barges", "value": "3" },
+    { "label": "Warlord Titansaw", "value": "3" }
+  ]
+}

--- a/page/factions/general.json
+++ b/page/factions/general.json
@@ -22,6 +22,7 @@
       "Event Cards",
       "Card Backs",
       "Faction Card",
+      "Material",
       "Map"
     ],
     "reference": [
@@ -30,6 +31,7 @@
       "events",
       "backs",
       "faction_card",
+      "material",
       "map"
     ]
   },

--- a/page/script/script.js
+++ b/page/script/script.js
@@ -454,12 +454,15 @@ document.addEventListener('DOMContentLoaded', async function () {
 										const cardsOrdersText = textData?.ordersText ?? false;
 										const cardsEventsText = textData?.eventsText ?? false;
 										const cardsCombatText = textData?.combatText ?? false;
-										if (cardTypeReference === "combat") {
-											createCombatContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameCombatList, cardsCombatText);
-										} else if (cardTypeReference === "orders") {
-											createOrdersContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameOrderList, cardsOrdersText);
-										} else if (cardTypeReference === "events") {
-											createEventContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameEventList, cardsEventsText);
+									const cardsMaterialsText = textData?.materialsText ?? false;
+									if (cardTypeReference === "combat") {
+										createCombatContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameCombatList, cardsCombatText);
+									} else if (cardTypeReference === "orders") {
+										createOrdersContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameOrderList, cardsOrdersText);
+									} else if (cardTypeReference === "events") {
+										createEventContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameEventList, cardsEventsText);
+									} else if (cardTypeReference === "material") {
+										createMaterialContent(subTabContents, expansionFolder___, factionFolder__, cardsMaterialsText);
 										} else if (cardTypeReference === "faction_card") {
 											createFactioncardContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameFactioncardList);
 										} else if (cardTypeReference === "backs") {
@@ -607,6 +610,56 @@ document.addEventListener('DOMContentLoaded', async function () {
 				placeholder.innerHTML = 'Error loading image';
 			});
 		});
+		container.appendChild(categoryContainer);
+	}
+
+	function createMaterialContent(container, expansionFolder, factionfolder, materialsText) {
+		const categoryContainer = document.createElement('div');
+		categoryContainer.classList.add('grid', 'materials');
+
+		const materialCard = document.createElement('div');
+		materialCard.classList.add('material-card');
+
+		const heading = document.createElement('div');
+		heading.classList.add('material-heading');
+		heading.textContent = 'Material';
+		materialCard.appendChild(heading);
+
+		const body = document.createElement('div');
+		body.classList.add('material-body');
+
+		if (materialsText && Array.isArray(materialsText) && materialsText.length) {
+			materialsText.forEach(item => {
+				const line = document.createElement('div');
+				line.classList.add('material-line');
+				if (typeof item === 'string') {
+					line.textContent = item;
+				} else if (item && typeof item === 'object') {
+					const label = document.createElement('span');
+					label.classList.add('material-label');
+					label.textContent = item.label || '';
+					const value = document.createElement('span');
+					value.classList.add('material-value');
+					value.textContent = item.value || '';
+					line.appendChild(label);
+					if (item.label && item.value) {
+						line.appendChild(document.createTextNode(': '));
+					}
+					line.appendChild(value);
+				} else {
+					line.textContent = String(item);
+				}
+				body.appendChild(line);
+			});
+		} else {
+			const empty = document.createElement('p');
+			empty.classList.add('material-empty');
+			empty.textContent = 'Material information not available for this faction.';
+			body.appendChild(empty);
+		}
+
+		materialCard.appendChild(body);
+		categoryContainer.appendChild(materialCard);
 		container.appendChild(categoryContainer);
 	}
 

--- a/page/style/styles.css
+++ b/page/style/styles.css
@@ -329,6 +329,67 @@ body {
     width: 1835px;
 }
 
+.grid.materials {
+    grid-template-columns: repeat(1, 1fr);
+    width: 100%;
+}
+
+.material-card {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 24px;
+    border-radius: 18px;
+    background: rgba(0, 0, 0, 0.24);
+    border: var(--border);
+    min-height: 450px;
+}
+
+.material-heading {
+    font-family: 'EventFont';
+    font-size: 36px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text_2);
+    border-bottom: 2px solid var(--highlight);
+    padding-bottom: 8px;
+}
+
+.material-body {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    font-family: 'ForbiddenStars';
+    font-size: 22px;
+    line-height: 1.6;
+    color: var(--text);
+}
+
+.material-line {
+    display: block;
+    padding: 10px 14px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.06);
+    white-space: normal;
+    word-break: break-word;
+}
+
+.material-label {
+    font-weight: 700;
+    display: inline-block;
+    margin-right: 8px;
+}
+
+.material-value {
+    display: inline;
+}
+
+.material-empty {
+    margin: 0;
+    opacity: 0.8;
+    font-size: 20px;
+}
+
 
 .grid.orders {
     grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
## Added Material tab to display unit counts

The webpage didn't show how many pieces of each unit are available. This PR adds a new "Material" tab to each faction showing unit quantities.

Scope: Implemented for base game factions. Other expansions can be populated in each factions text.json
(Maybe I'll do a follow up PR to include them)