### PR TITLE
feat: redesign card codex UI (Forbidden Stars Codex)

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -4,30 +4,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Forbidden Star - Fan Factions</title>
-    <link rel="stylesheet" href="style\styles.css">
-    <link rel="apple-touch-icon" sizes="180x180" href="\apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="\favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="\favicon-16x16.png">
-    <link rel="manifest" href="page\site.webmanifest">
+    <title>Forbidden Stars — Card Codex</title>
+    <meta name="description" content="An online library of Forbidden Stars boardgame cards — browse every faction's combat, order, event and map cards.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="style/styles.css">
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
+    <link rel="manifest" href="site.webmanifest">
 </head>
 
 <body>
-    <div id="expansion-tabs"></div>
-    <div id="faction-tabs"></div>
-    <div id="cards-tabs"></div>
-    <div id="cards-container"></div>
-    <div id="faq-container" class="faq-container">
-        <div class="faq-page-shell">
-            <div class="faq-header-panel">
-                <div class="faq-search-wrap">
-                    <input id="faq-search-input" class="faq-search-box" type="text" placeholder="Search the FAQ..." />
-                    <div id="faq-search-meta" class="faq-search-meta">Showing full FAQ</div>
-                </div>
-            </div>
-            <main id="faq-content" class="faq-content" aria-live="polite"></main>
-        </div>
-    </div>
+    <div id="app"></div>
     <script src="script/script.js"></script>
 </body>
 

--- a/page/script/script.js
+++ b/page/script/script.js
@@ -1,966 +1,377 @@
-async function preloadCanvasFonts() {
-    if (!document.fonts) {
-        return;
+/* Forbidden Stars — Card Codex
+ * Vanilla port of the "Forbidden Stars Codex" Claude Design component.
+ * No framework / no build step. Renders into #app and drives a tiny state store.
+ *
+ * Image assets live at:  factions/<expansion>/<faction>/<folder>/<file>
+ * Only the `base` expansion ships artwork; other expansions render an empty state.
+ */
+(function () {
+  'use strict';
+
+  /* ---------------- data ---------------- */
+
+  var ACCENT = 'amber'; // amber | steel | crimson  (drives --fs-accent CSS vars)
+  var DENSITY = 4;      // grid columns for standard card categories (desktop)
+
+  // Standard-card grid columns adapt to viewport width so cards stay legible on
+  // phones/tablets. Map (2) and Faction Card (1) layouts are unaffected.
+  function density() {
+    var w = window.innerWidth || 1200;
+    if (w <= 480) return 2;
+    if (w <= 720) return 3;
+    if (w <= 1024) return DENSITY - 1;
+    return DENSITY;
+  }
+
+  var EXPANSIONS = [
+    { key: 'base',    name: 'Base Game',          available: true },
+    { key: 'gif',     name: 'Galaxy in Flames',   available: false },
+    { key: 'sow',     name: 'Symphony of War',    available: false },
+    { key: 'emperor', name: 'The Dying Light',    available: false },
+    { key: 'dd',      name: 'Darkest Dawn',       available: false },
+  ];
+
+  var FACTIONS = [
+    { key: 'spacemarines', name: 'Space Marines', dot: 'oklch(0.64 0.12 245)' },
+    { key: 'chaos',        name: 'Chaos',         dot: 'oklch(0.57 0.19 25)'  },
+    { key: 'ork',          name: 'Ork',           dot: 'oklch(0.66 0.15 142)' },
+    { key: 'eldar',        name: 'Eldar',         dot: 'oklch(0.80 0.13 90)'  },
+  ];
+
+  var CATEGORIES = [
+    { key: 'combat',       name: 'Combat'       },
+    { key: 'orders',       name: 'Orders'       },
+    { key: 'events',       name: 'Events'       },
+    { key: 'backs',        name: 'Card Backs'   },
+    { key: 'faction_card', name: 'Faction Card' },
+    { key: 'map',          name: 'Maps'         },
+  ];
+
+  var FOLDER = {
+    combat: 'combat', orders: 'orders', events: 'events',
+    backs: 'backs', faction_card: 'faction_card', map: 'maps',
+  };
+
+  var COMBAT = [
+    { label: 'Standard', files: ['s1.jpg', 's2.jpg', 's3.jpg', 's4.jpg', 's5.jpg'] },
+    { label: 'Tier I',   files: ['t0_1.jpg', 't0_2.jpg', 't0_3.jpg', 't0_4.jpg'] },
+    { label: 'Tier II',  files: ['t2_1.jpg', 't2_2.jpg', 't2_3.jpg'] },
+    { label: 'Tier III', files: ['t3_1.jpg', 't3_2.jpg'] },
+  ];
+
+  var SIMPLE = {
+    orders:       ['o_1.jpg', 'o_2.jpg', 'o_3.jpg', 'o_4.jpg', 'o_5.jpg'],
+    events:       ['e_1.jpg', 'e_2.jpg', 'e_3.jpg', 'e_4.jpg', 'e_5.jpg', 'e_6.jpg', 'e_7.jpg', 'e_8.jpg'],
+    backs:        ['combat.jpg', 'order.jpg', 'event.jpg'],
+    faction_card: ['card.jpg'],
+    map:          ['map_A.jpg', 'map_B.jpg'],
+  };
+
+  var ACC = {
+    amber:   { a: 'oklch(0.80 0.12 80)',  fg: '#1c1810' },
+    steel:   { a: 'oklch(0.72 0.10 232)', fg: '#0b1019' },
+    crimson: { a: 'oklch(0.62 0.185 25)', fg: '#1c0d0c' },
+  };
+
+  /* ---------------- state ---------------- */
+
+  var state = { expansion: 'base', faction: 'spacemarines', category: 'combat', lb: null };
+  var flat = []; // flat list of currently-visible cards, for the lightbox
+
+  function setState(patch) {
+    for (var k in patch) { if (patch.hasOwnProperty(k)) state[k] = patch[k]; }
+    render();
+  }
+
+  /* ---------------- helpers ---------------- */
+
+  function facName(k) { var f = find(FACTIONS, k); return f ? f.name : ''; }
+  function catName(k) { var c = find(CATEGORIES, k); return c ? c.name : ''; }
+  function find(list, key) {
+    for (var i = 0; i < list.length; i++) { if (list[i].key === key) return list[i]; }
+    return null;
+  }
+
+  // tiny element builder: el('div', {class:'x', onclick:fn, html:'...'}, [children])
+  function el(tag, props, children) {
+    var node = document.createElement(tag);
+    props = props || {};
+    for (var key in props) {
+      if (!props.hasOwnProperty(key)) continue;
+      var val = props[key];
+      if (val == null) continue;
+      if (key === 'class') node.className = val;
+      else if (key === 'html') node.innerHTML = val;
+      else if (key === 'text') node.textContent = val;
+      else if (key.indexOf('on') === 0 && typeof val === 'function') {
+        node.addEventListener(key.slice(2).toLowerCase(), val);
+      } else {
+        node.setAttribute(key, val);
+      }
+    }
+    if (children) {
+      if (!Array.isArray(children)) children = [children];
+      for (var i = 0; i < children.length; i++) {
+        var c = children[i];
+        if (c == null || c === false) continue;
+        node.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+      }
+    }
+    return node;
+  }
+
+  /* ---------------- card model ---------------- */
+
+  function build() {
+    var fac = state.faction, cat = state.category;
+    var base = 'factions/' + state.expansion + '/' + fac + '/' + FOLDER[cat] + '/';
+    var groups = [];
+    flat = [];
+
+    function push(file, label) {
+      var idx = flat.length;
+      var c = { src: base + file, label: label, index: idx };
+      flat.push(c);
+      return c;
     }
 
-    const families = ['ForbiddenStars', 'Headline', 'EventFont'];
-    const fontLoads = families.map(family => document.fonts.load(`1em ${family}`));
-
-    try {
-        await Promise.all([...fontLoads, document.fonts.ready]);
-    } catch (error) {
-        console.warn('Some canvas fonts did not finish loading before the first draw.', error);
+    if (cat === 'combat') {
+      COMBAT.forEach(function (sec) {
+        var cards = sec.files.map(function (f, i) {
+          return push(f, facName(fac) + ' · ' + sec.label + ' ' + (i + 1));
+        });
+        groups.push({ label: sec.label, sub: cards.length + ' cards', cards: cards });
+      });
+    } else {
+      var labels;
+      if (cat === 'backs') labels = ['Combat Deck Back', 'Order Deck Back', 'Event Deck Back'];
+      else if (cat === 'faction_card') labels = [facName(fac) + ' Reference'];
+      else if (cat === 'map') labels = ['Map A', 'Map B'];
+      else {
+        var pre = cat === 'orders' ? 'Order Upgrade' : 'Event';
+        labels = SIMPLE[cat].map(function (_, i) { return pre + ' ' + (i + 1); });
+      }
+      var cards = SIMPLE[cat].map(function (f, i) { return push(f, labels[i]); });
+      groups.push({ label: null, sub: '', cards: cards });
     }
-}
-
-document.addEventListener('DOMContentLoaded', async function () {
-	await preloadCanvasFonts();
-	const expansionTabsContainer = document.getElementById('expansion-tabs');
-	const factionTabsContainer = document.getElementById('faction-tabs');
-	const cardsContentsContainer = document.getElementById('cards-tabs');
-	const cardsContainer = document.getElementById('cards-container');
-	const faqContainer = document.getElementById('faq-container');
-	const faqContent = document.getElementById('faq-content');
-	const faqSearchInput = document.getElementById('faq-search-input');
-	const faqSearchMeta = document.getElementById('faq-search-meta');
-	const FAQ_JSON_PATH = './data/FAQ.json';
-
-	let faqOriginalData = [];
-	let faqLoaded = false;
-	let faqLoadingPromise = null;
-
-	const normalizeFaqValue = (value) => String(value ?? '').toLowerCase();
-	const faqMatches = (value, query) => normalizeFaqValue(value).includes(query);
-	const faqEscapeHtml = (str) => String(str ?? '')
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/\"/g, '&quot;')
-		.replace(/'/g, '&#039;');
-	const faqWithArray = (value) => Array.isArray(value) ? value : [];
-	const getFaqPicture = (node) => node && typeof node === 'object' ? node.picture || '' : '';
-
-	function normalizeFaqMainText(value) {
-		return String(value ?? '')
-			.replace(/\\r\\n/g, '\n')
-			.replace(/\\n/g, '\n');
-	}
-
-	function highlightFaqText(text, query) {
-		const raw = String(text ?? '');
-		if (!query) {
-			return faqEscapeHtml(raw);
-		}
-
-		const escaped = faqEscapeHtml(raw);
-		const safeQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-		const regex = new RegExp(`(${safeQuery})`, 'ig');
-		return escaped.replace(regex, '<mark>$1</mark>');
-	}
-
-	function createFaqLevelRow(textHtml, picture) {
-		const row = document.createElement('div');
-		row.className = `faq-level-row ${picture ? '' : 'no-picture'}`.trim();
-
-		const textWrap = document.createElement('div');
-		textWrap.innerHTML = textHtml;
-		row.appendChild(textWrap);
-
-		if (picture) {
-			const img = document.createElement('img');
-			img.className = 'faq-level-image';
-			img.src = picture;
-			img.alt = '';
-			img.loading = 'lazy';
-			row.appendChild(img);
-		}
-		return row;
-	}
-
-	function renderFaqPhraseBlock(phraseObj, query) {
-		const phraseBlock = document.createElement('section');
-		phraseBlock.className = 'faq-phrase-block faq-level-block';
-
-		const phraseText = phraseObj.Phrase ?? '';
-		const mainText = normalizeFaqMainText(phraseObj.Main ?? '');
-		const picture = getFaqPicture(phraseObj);
-
-		const textHtml = `
-			<div class="faq-phrase-title"><strong>${highlightFaqText(phraseText, query)}</strong></div>
-			<div class="faq-main-text">${highlightFaqText(mainText, query)}</div>
-		`;
-
-		phraseBlock.appendChild(createFaqLevelRow(textHtml, picture));
-		return phraseBlock;
-	}
-
-	function renderFaqFactionBlock(factionObj, query) {
-		const block = document.createElement('section');
-		block.className = 'faq-faction-block faq-level-block';
-
-		const title = factionObj.Faction ?? '';
-		const picture = getFaqPicture(factionObj);
-		const headerHtml = `
-			<h3>${highlightFaqText(title, query)}</h3>
-			<div class="faq-separator"></div>
-		`;
-
-		block.appendChild(createFaqLevelRow(headerHtml, picture));
-
-		faqWithArray(factionObj.items).forEach((phraseObj) => {
-			block.appendChild(renderFaqPhraseBlock(phraseObj, query));
-		});
-
-		return block;
-	}
-
-	function renderFaqSubCategoryBlock(subObj, query) {
-		const block = document.createElement('section');
-		block.className = 'faq-subcategory-block faq-level-block';
-
-		const title = subObj.SubCategory ?? '';
-		const picture = getFaqPicture(subObj);
-		const headerHtml = `
-			<h2>${highlightFaqText(title, query)}</h2>
-			<div class="faq-separator"></div>
-		`;
-
-		block.appendChild(createFaqLevelRow(headerHtml, picture));
-
-		faqWithArray(subObj.items).forEach((factionObj) => {
-			block.appendChild(renderFaqFactionBlock(factionObj, query));
-		});
-
-		return block;
-	}
-
-	function renderFaqCategoryBlock(categoryObj, query) {
-		const block = document.createElement('section');
-		block.className = 'faq-category-block faq-level-block';
-
-		const title = categoryObj.Category ?? '';
-		const picture = getFaqPicture(categoryObj);
-		const headerHtml = `
-			<h1>${highlightFaqText(title, query)}</h1>
-			<div class="faq-separator"></div>
-		`;
-
-		block.appendChild(createFaqLevelRow(headerHtml, picture));
-
-		faqWithArray(categoryObj.items).forEach((subObj) => {
-			block.appendChild(renderFaqSubCategoryBlock(subObj, query));
-		});
-
-		return block;
-	}
-
-	function renderFaq(data, query = '') {
-		if (!faqContent) {
-			return;
-		}
-
-		faqContent.innerHTML = '';
-
-		if (!data.length) {
-			const empty = document.createElement('div');
-			empty.className = 'faq-empty-state';
-			empty.textContent = query ? 'No results found.' : 'No FAQ entries available.';
-			faqContent.appendChild(empty);
-			return;
-		}
-
-		data.forEach((categoryObj) => {
-			faqContent.appendChild(renderFaqCategoryBlock(categoryObj, query));
-		});
-	}
-
-	function filterFaqData(data, rawQuery) {
-		const query = normalizeFaqValue(rawQuery).trim();
-		if (!query) {
-			return data;
-		}
-
-		return faqWithArray(data).flatMap((categoryObj) => {
-			const filteredSubCategories = faqWithArray(categoryObj.items).flatMap((subObj) => {
-				if (faqMatches(subObj.SubCategory, query)) {
-					return [subObj];
-				}
-
-				const filteredFactions = faqWithArray(subObj.items).flatMap((factionObj) => {
-					if (faqMatches(factionObj.Faction, query)) {
-						return [factionObj];
-					}
-
-					const filteredPhrases = faqWithArray(factionObj.items).filter((phraseObj) => {
-						return faqMatches(phraseObj.Phrase, query) || faqMatches(phraseObj.Main, query);
-					});
-
-					if (filteredPhrases.length) {
-						return [{
-							...factionObj,
-							items: filteredPhrases
-						}];
-					}
-
-					return [];
-				});
-
-				if (filteredFactions.length) {
-					return [{
-						...subObj,
-						items: filteredFactions
-					}];
-				}
-
-				return [];
-			});
-
-			if (filteredSubCategories.length) {
-				return [{
-					...categoryObj,
-					items: filteredSubCategories
-				}];
-			}
-
-			return [];
-		});
-	}
-
-	function updateFaqSearchResults(rawQuery) {
-		const query = rawQuery.trim();
-		const filtered = filterFaqData(faqOriginalData, rawQuery);
-		renderFaq(filtered, query);
-
-		if (faqSearchMeta) {
-			faqSearchMeta.textContent = query
-				? `Search: "${query}"`
-				: 'Showing full FAQ';
-		}
-	}
-
-	async function loadFaq() {
-		if (faqLoaded) {
-			return faqOriginalData;
-		}
-
-		if (faqLoadingPromise) {
-			return faqLoadingPromise;
-		}
-
-		faqLoadingPromise = fetch(FAQ_JSON_PATH, { cache: 'no-store' })
-			.then((response) => {
-				if (!response.ok) {
-					throw new Error(`Failed to load FAQ JSON: ${response.status}`);
-				}
-
-				return response.json();
-			})
-			.then((data) => {
-				faqOriginalData = Array.isArray(data) ? data : [];
-				faqLoaded = true;
-				updateFaqSearchResults(faqSearchInput?.value ?? '');
-				return faqOriginalData;
-			})
-			.catch((error) => {
-				console.error(error);
-				faqLoaded = false;
-
-				if (faqContent) {
-					faqContent.innerHTML = '<div class="faq-empty-state">Failed to load FAQ data.</div>';
-				}
-
-				throw error;
-			})
-			.finally(() => {
-				faqLoadingPromise = null;
-			});
-
-		return faqLoadingPromise;
-	}
-
-	const showCardsView = () => {
-		if (factionTabsContainer) factionTabsContainer.style.display = '';
-		if (cardsContentsContainer) cardsContentsContainer.style.display = '';
-		if (cardsContainer) cardsContainer.style.display = '';
-		if (faqContainer) faqContainer.classList.remove('active');
-	};
-
-	const showFaqView = () => {
-		if (factionTabsContainer) factionTabsContainer.style.display = 'none';
-		if (cardsContentsContainer) cardsContentsContainer.style.display = 'none';
-		if (cardsContainer) cardsContainer.style.display = 'none';
-		if (faqContainer) faqContainer.classList.add('active');
-		loadFaq().catch(() => {});
-	};
-
-	if (faqSearchInput) {
-		faqSearchInput.addEventListener('input', (event) => {
-			updateFaqSearchResults(event.target.value);
-		});
-	}
-
-	// Size of cards - rest is calculated just based on this.
-	const maxWidth = 450;
-	const maxHeight = 650;
-
-	// Size of boxes for combat cards.
-	const textBackgroundSize = 759;
-	const textBottomBarHeight = 18;
-	const textBottomBarWidth = 454;
-
-	const titleFontSize = maxHeight * 0.05;
-	const marginWidth = maxWidth * 0.0578;
-	const maxTextWidth = maxWidth - 2 * marginWidth;
-
-	// Icons positioning predefinitions.
-	const iconSize = maxWidth * 0.097;
-	const iconSpacing = maxWidth * 0.011;
-	const iconX = maxWidth * 0.0632;
-	const startY = maxHeight * 0.242;
-
-	const iconMap = {
-		'B': 'pictures/bolter.png',
-		'S': 'pictures/shield.png',
-		'M': 'pictures/moral.png'
-	};
-
-	// MENU SECTION BUILDER
-	fetch('factions/general.json')
-		.then(response => response.json())
-		.then(generalData => {
-			var firstRun = true;
-			expansionTabsContainer.innerHTML = '';
-
-			const expansionFolderList = generalData.expansion.folder;
-			const expansionNameList = generalData.expansion.name;
-
-			expansionFolderList.forEach((expansionFolder, expansionFolderIndex) => {
-				const expansionTabHeader = document.createElement('div');
-				expansionTabHeader.textContent = expansionNameList[expansionFolderIndex];
-				expansionTabHeader.classList.add('expansion-header');
-				expansionTabHeader.dataset.expansion = expansionFolder;
-				if (expansionFolderIndex === 0) expansionTabHeader.classList.add('active');
-				expansionTabsContainer.appendChild(expansionTabHeader);
-			});
-
-			const faqTabHeader = document.createElement('div');
-			faqTabHeader.textContent = 'FAQ';
-			faqTabHeader.classList.add('expansion-header');
-			faqTabHeader.dataset.expansion = 'faq';
-			faqTabHeader.dataset.special = 'faq';
-			expansionTabsContainer.appendChild(faqTabHeader);
-
-			expansionTabsContainer.addEventListener('click', function (e) {
-				if (e.target.classList.contains('expansion-header')) {
-					const isFaqTab = e.target.dataset.special === 'faq';
-					const buttonExp = e.target.dataset.expansion;
-					document.querySelectorAll('.expansion-header').forEach(h => h.classList.remove('active'));
-					e.target.classList.add('active');
-					if (isFaqTab) {
-						showFaqView();
-					} else {
-						showCardsView();
-						loadFactions(buttonExp);
-					}
-				}
-			});
-
-			if (firstRun === true) {
-				showCardsView();
-				loadFactions(expansionFolderList[0]);
-			}
-
-			function loadFactions(expansionFolder_) {
-				factionTabsContainer.innerHTML = '';
-				fetch('factions/' + expansionFolder_ + '/faction.json')
-					.then(response => response.json())
-					.then(expansionData => {
-
-						const factionFolderList = expansionData.folder;
-						const factionNameList = expansionData.name;
-
-						factionFolderList.forEach((factionFolder, factionFolderIndex) => {
-							const factionTabHeader = document.createElement('div');
-							factionTabHeader.textContent = factionNameList[factionFolderIndex];
-							factionTabHeader.classList.add('faction-header');
-							factionTabHeader.dataset.faction = factionFolder;
-							factionTabHeader.dataset.expansion = expansionFolder_;
-							if (factionFolderIndex === 0) factionTabHeader.classList.add('active');
-							factionTabsContainer.appendChild(factionTabHeader);
-						});
-
-						factionTabsContainer.addEventListener('click', function (e) {
-							if (e.target.classList.contains('faction-header')) {
-								const buttonExp = e.target.dataset.expansion;
-								const buttonFac = e.target.dataset.faction;
-								document.querySelectorAll('.faction-header').forEach(h => h.classList.remove('active'));
-								e.target.classList.add('active');
-								loadCardsMenu(buttonExp, buttonFac);
-							}
-						});
-
-						if (firstRun) {
-							loadCardsMenu(expansionFolder_, factionFolderList[0]);
-						}
-
-						function loadCardsMenu(expansionFolder__, factionFolder_) {
-
-							const cardsDefaultName = generalData.cardsDefault.name;
-							const cardsDefaultReference = generalData.cardsDefault.reference;
-							cardsContentsContainer.innerHTML = '';
-							cardsDefaultReference.forEach((reference, referenceIndex) => {
-								const cardTabHeader = document.createElement('div');
-								cardTabHeader.textContent = cardsDefaultName[referenceIndex];
-								cardTabHeader.classList.add('card-header');
-								cardTabHeader.dataset.faction = factionFolder_;
-								cardTabHeader.dataset.expansion = expansionFolder__;
-								cardTabHeader.dataset.cardType = reference;
-								if (referenceIndex === 0) cardTabHeader.classList.add('active');
-								cardsContentsContainer.appendChild(cardTabHeader);
-							});
-
-							cardsContentsContainer.addEventListener('click', function (e) {
-								if (e.target.classList.contains('card-header')) {
-									const buttonExp = e.target.dataset.expansion;
-									const buttonFac = e.target.dataset.faction;
-									const buttonCard = e.target.dataset.cardType;
-									document.querySelectorAll('.card-header').forEach(h => h.classList.remove('active'));
-									e.target.classList.add('active');
-									loadCards(buttonExp, buttonFac, buttonCard);
-								}
-							});
-
-							if (firstRun) {
-								loadCards(expansionFolder__, factionFolder_, cardsDefaultReference[0]);
-							}
-
-							function loadCards(expansionFolder___, factionFolder__, cardTypeReference) {
-								cardsContainer.innerHTML = '';
-								const subTabContents = document.createElement('div');
-								subTabContents.classList.add('card-contents');
-								subTabContents.id = `cards-${expansionFolder___}-${factionFolder__}-${cardTypeReference}`;
-								cardsContainer.appendChild(subTabContents);
-
-								fetch(`factions/${expansionFolder___}/${factionFolder__}/text.json`)
-									.then(response => response.ok ? response.json() : "")
-									.then(textData => {
-										console.log(textData);
-										const cardsFilenameCombatList = textData?.filenames?.combat ?? generalData.filenames.combat;
-										const cardsFilenameOrderList = textData?.filenames?.orders ?? generalData.filenames.orders;
-										const cardsFilenameEventList = textData?.filenames?.events ?? generalData.filenames.events;
-										const cardsFilenameFactioncardList = textData?.filenames?.faction_card ?? generalData.filenames.faction_card;
-										const cardsFilenameBacksList = textData?.filenames?.backs ?? generalData.filenames.backs;
-										const cardsFilenameMapList = textData?.filenames?.map ?? generalData.filenames.map;
-										const cardsOrdersText = textData?.ordersText ?? false;
-										const cardsEventsText = textData?.eventsText ?? false;
-										const cardsCombatText = textData?.combatText ?? false;
-										if (cardTypeReference === "combat") {
-											createCombatContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameCombatList, cardsCombatText);
-										} else if (cardTypeReference === "orders") {
-											createOrdersContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameOrderList, cardsOrdersText);
-										} else if (cardTypeReference === "events") {
-											createEventContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameEventList, cardsEventsText);
-										} else if (cardTypeReference === "faction_card") {
-											createFactioncardContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameFactioncardList);
-										} else if (cardTypeReference === "backs") {
-											backCardContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameBacksList);
-										} else if (cardTypeReference === "map") {
-											mapCardContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameMapList);
-										}
-									})
-									.catch(error => console.error('Error loading text.json:', error));
-							};
-						};
-					});
-			};
-		})
-		.catch(error => console.error('Error loading file_names.json:', error));
-	firstRun = false;
-
-	function createPlaceholderWithSpinner() {
-			const placeholder = document.createElement('div');
-			placeholder.classList.add('card-placeholder');
-			const spinner = document.createElement('div');
-			spinner.classList.add('card-spinner');
-			placeholder.appendChild(spinner);
-			return placeholder;
-	}
-
-	//   CREATING CONTENT FOR CANVAS
-	function createCombatContent(container, expansionFolder, factionfolder, files, textData) {
-		const sections = {
-			's-section': files[0],
-			't1-section': files[1],
-			't2-section': files[2],
-			't3-section': files[3]
-		};
-
-		const combatText = textData
-			? {
-				's-section': textData[0],
-				't1-section': textData[1],
-				't2-section': textData[2],
-				't3-section': textData[3]
-			} : false;
-		
-		Object.keys(sections).forEach(section => {
-			const sectionContainer = document.createElement('div');
-			sectionContainer.classList.add('grid', 'combat', section);
-			sections[section].forEach((file, idx) => {
-				// Create placeholder with spinner
-				const placeholder = createPlaceholderWithSpinner();
-				sectionContainer.appendChild(placeholder);
-
-				// Prepare card data
-				const jsonData = {};
-				jsonData["picture"] = `factions/${expansionFolder}/${factionfolder}/combat/${file}`;
-				if (combatText) {
-					jsonData["hasText"] = true;
-					jsonData["title"] = combatText[section][idx].title || "";
-					jsonData["background"] = combatText[section][idx].general || "";
-					jsonData["foreground"] = combatText[section][idx].unit || "";
-					jsonData["icons"] = combatText[section][idx].icons || "";
-				} else {
-					jsonData["hasText"] = false;
-				}
-
-				const canvas = document.createElement('canvas');
-				canvas.width = maxWidth;
-				canvas.height = maxHeight;
-				const context = canvas.getContext('2d');
-
-				drawCombatCard(jsonData, context).then(() => {
-					placeholder.replaceWith(canvas);
-				}).catch(err => {
-					console.error('Error drawing combat card:', err);
-					placeholder.innerHTML = 'Error loading image';
-				});
-			});
-			container.appendChild(sectionContainer);
-		});
-	}
-
-
-	function createOrdersContent(container, expansionFolder, factionfolder, files, textData) {
-		const categoryContainer = document.createElement('div');
-		categoryContainer.classList.add('grid', 'orders');
-
-		files.forEach((file, idx) => {
-			const placeholder = createPlaceholderWithSpinner();
-			categoryContainer.appendChild(placeholder);
-			const jsonData = {};
-			jsonData["picture"] = `factions/${expansionFolder}/${factionfolder}/orders/${file}`;
-			if (textData) {
-				jsonData["hasText"] = true;
-				jsonData["title"] = `${textData[idx].title}`;
-				jsonData["general"] = `${textData[idx].general}`;
-			} else {
-				jsonData["hasText"] = false;
-			}
-
-			const canvas = document.createElement('canvas');
-			canvas.width = maxWidth;
-			canvas.height = maxHeight;
-			const context = canvas.getContext('2d');
-
-			// Draw card and replace placeholder when done
-			drawOrderCard(jsonData, context).then(() => {
-				placeholder.replaceWith(canvas);
-			}).catch(err => {
-				console.error('Error drawing order card:', err);
-				placeholder.innerHTML = 'Error loading image';
-			});
-		});
-
-		container.appendChild(categoryContainer);
-	}
-
-	function createEventContent(container, expansionFolder, factionfolder, files, textData) {
-		const categoryContainer = document.createElement('div');
-		categoryContainer.classList.add('grid', 'events');
-
-		files.forEach((file, idx) => {
-			const placeholder = createPlaceholderWithSpinner();
-			categoryContainer.appendChild(placeholder);
-			const jsonData = {};
-			jsonData["picture"] = `factions/${expansionFolder}/${factionfolder}/events/${file}`;
-
-			if (textData) {
-				jsonData["hasText"] = true;
-				jsonData["title"] = `${textData[idx].title}`;
-				jsonData["general"] = `${textData[idx].general}`;
-				jsonData["type"] = `${textData[idx].type}`;
-			} else {
-				jsonData["hasText"] = false;
-			}
-
-			const canvas = document.createElement('canvas');
-			canvas.width = maxWidth;
-			canvas.height = maxHeight;
-			const context = canvas.getContext('2d');
-
-			// Draw card and replace placeholder when done
-			drawEventCard(jsonData, context).then(() => {
-				placeholder.replaceWith(canvas);
-			}).catch(err => {
-				console.error('Error drawing event card:', err);
-				placeholder.innerHTML = 'Error loading image';
-			});
-		});
-		container.appendChild(categoryContainer);
-	}
-
-function imageLoaderUniversal(files, maxWidth, maxHeight, pathToImage, container, categoryContainer) {
-	files.forEach((file, _) => {
-			const placeholder = createPlaceholderWithSpinner();
-			categoryContainer.appendChild(placeholder);
-			const img = document.createElement('img');
-			img.src = pathToImage+file;
-			if (maxWidth) img.width = maxWidth;
-			if (maxHeight) img.height = maxHeight;
-			img.onload = () => {
-				placeholder.replaceWith(img);
-			};
-			img.onerror = () => {
-				placeholder.innerHTML = 'Error loading image';
-			};
-		});
-		container.appendChild(categoryContainer);
-}
-
-	function createFactioncardContent(container, expansionFolder, factionfolder, files) {
-		const categoryContainer = document.createElement('div');
-		categoryContainer.classList.add('grid','factionCardImage');
-		imageLoaderUniversal(files, maxWidth*3, false, `factions/${expansionFolder}/${factionfolder}/faction_card/`, container, categoryContainer);
-	}
-
-	function backCardContent(container, expansionFolder, factionfolder, files) {
-		const categoryContainer = document.createElement('div');
-		categoryContainer.classList.add('grid', 'cardBackImages');
-		imageLoaderUniversal(files, maxWidth, maxHeight, `factions/${expansionFolder}/${factionfolder}/backs/`, container, categoryContainer);
-	}
-
-	function mapCardContent(container, expansionFolder, factionfolder, files) {
-		const categoryContainer = document.createElement('div');
-		categoryContainer.classList.add('grid', 'mapImages');
-		imageLoaderUniversal(files, maxWidth*2, false, `factions/${expansionFolder}/${factionfolder}/maps/`, container, categoryContainer);
-	}
-
-	// CANVAS TOOLS
-	function replaceForbiddenStarsElements(str) {
-		str = str.replace(/\[B\]/g, "}");
-		str = str.replace(/\[S\]/g, "{");
-		str = str.replace(/\[M\]/g, "<");
-		str = str.replace(/\[D\]/g, "|");
-		str = str.replace(/\(B\)/g, "#");
-		str = str.replace(/\(S\)/g, "@");
-		return str
-	}
-
-	function calculateTextHeight(context, text, extraHeight, marginHeight, interline, fontSize) {
-		context.font = `${fontSize}px ForbiddenStars`;
-		const words = text.split(' ');
-		let line = '';
-		let lineHeight = parseInt(context.font.match(/\d+/), 10);
-		let returnHeight = 0;
-		for (let n = 0; n < words.length; n++) {
-			if (words[n] === "*newline*") {
-				returnHeight += lineHeight + interline;
-				line = '';
-			}
-			else if (words[n] === "*newpara*") {
-				returnHeight += 2 * lineHeight;
-				line = '';
-			}
-			else {
-				const testLine = line + words[n] + ' ';
-				const metrics = context.measureText(testLine);
-				if (metrics.width > maxTextWidth && n > 0) {
-					returnHeight += lineHeight + interline;
-					line = words[n] + ' ';
-				} else {
-					line = testLine;
-				}
-			}
-		}
-		returnHeight += lineHeight * 2 + extraHeight + marginHeight * 2;
-		return returnHeight;
-	};
-
-
-	function loadImage(url) {
-		return new Promise((resolve, reject) => {
-			const img = new Image();
-			img.src = url;
-			img.onload = () => resolve(img);
-			img.onerror = () => reject(new Error('Failed to load image'));
-		});
-	};
-
-	// DRAWING CANVAS SECTION
-	async function drawCombatCard(data, ctx) {
-		const bottomImageheight = maxHeight * 0.025;
-		const maxFieldsHeight = maxHeight * 0.4;
-		const extraForegroundTriangle = maxHeight * 0.0455;
-		const extraBackgroundborder = maxHeight * 0.0385;
-
-		let interline = maxHeight * 0.0077;
-		let marginHeight = maxWidth * 0.05;
-		let fontSize = maxHeight * 0.03;
-
-		// Load images from paths
-		const picture = await loadImage(data.picture);
-		const background = await loadImage('pictures/background.png');
-		const foreground = await loadImage('pictures/foreground.png');
-		const bottomImage = await loadImage('pictures/bottom.png');
-
-		// Initial settings for margin and font size
-		let backgroundTextHeight = 0;
-		let foregroundTextHeight = 0;
-
-		// Draw the main picture resized
-		if (!data.hasText) {
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-
-		} else {
-
-			const backgroundWithFbElements = replaceForbiddenStarsElements(data.background)
-			const foregroundWithFbElements = replaceForbiddenStarsElements(data.foreground)
-
-			// Cards text height Declaration
-			const recalculateTextHeight = () => {
-				if (data.background.length > 0) {
-					backgroundTextHeight = calculateTextHeight(ctx, backgroundWithFbElements, extraBackgroundborder, marginHeight, interline, fontSize);
-				}
-				if (data.foreground.length > 0) {
-					foregroundTextHeight = calculateTextHeight(ctx, foregroundWithFbElements, extraForegroundTriangle, marginHeight, interline, fontSize);
-				}
-			};
-			recalculateTextHeight()
-
-			const resizeCardText = () => {
-				marginHeight *= 0.8;
-				fontSize *= 0.99;
-				interline *= 0.95;
-				recalculateTextHeight();
-			};
-
-			if (data.background.length > 0 && data.foreground.length > 0) {
-				while ((backgroundTextHeight + foregroundTextHeight) > maxFieldsHeight) {
-					resizeCardText();
-				};
-			} else {
-				while (Math.max(backgroundTextHeight, foregroundTextHeight) > maxFieldsHeight) {
-					resizeCardText();
-				};
-			};
-
-			const drawText = (text, yPosition, extra) => {
-				ctx.font = `${fontSize}px ForbiddenStars`;
-				const words = text.split(' ');
-				let line = '';
-				let lineHeight = parseInt(ctx.font.match(/\d+/), 10);
-				yPosition += marginHeight + extra + lineHeight;
-				for (let n = 0; n < words.length; n++) {
-					if (words[n] === "*newline*") {
-						ctx.fillText(line, marginWidth, yPosition);
-						yPosition += lineHeight + interline;
-						line = '';
-					}
-					else if (words[n] === "*newpara*") {
-						ctx.fillText(line, marginWidth, yPosition);
-						yPosition += 2 * lineHeight;
-						line = '';
-					}
-					else {
-						const testLine = line + words[n] + ' ';
-						const metrics = ctx.measureText(testLine);
-						if (metrics.width > maxWidth - 2 * marginWidth && n > 0) {
-							ctx.fillText(line, marginWidth, yPosition);
-							yPosition += lineHeight + interline;
-							line = words[n] + ' ';
-						} else {
-							line = testLine;
-						};
-					};
-				};
-				ctx.fillText(line, marginWidth, yPosition);
-			};
-
-			const drawImageCropped = (img, height) => {
-				ctx.drawImage(img, 0, 0, textBackgroundSize, maxHeight - height, 0, height, maxWidth, maxHeight - height);
-			};
-
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-			ctx.font = `${titleFontSize}px Headline`;
-			ctx.fillText(data.title, maxWidth * 0.27, maxHeight * 0.077);
-
-			if (data.background.length > 0) {
-				const backgroundY = maxHeight - (backgroundTextHeight + foregroundTextHeight);
-				drawImageCropped(background, backgroundY);
-				drawText(backgroundWithFbElements, backgroundY, extraBackgroundborder);
-			}
-			if (data.foreground.length > 0) {
-				const foregroundY = maxHeight - (foregroundTextHeight + extraForegroundTriangle * 0.35);
-				drawImageCropped(foreground, foregroundY);
-				drawText(foregroundWithFbElements, foregroundY, extraForegroundTriangle);
-			}
-			if (data.icons && data.icons.length > 0) {
-				let currentY = startY;
-				for (let letterPosition = 0; letterPosition < data.icons.length; letterPosition++) {
-					const iconChar = data.icons[letterPosition].toUpperCase();
-					if (iconMap[iconChar]) {
-						const iconImg = await loadImage(iconMap[iconChar]);
-						ctx.drawImage(iconImg, iconX, currentY, iconSize, iconSize);
-						currentY += iconSize + iconSpacing;
-					}
-				}
-			}
-			ctx.drawImage(bottomImage, 0, 0, textBottomBarWidth, textBottomBarHeight, 0, maxHeight - bottomImageheight, maxWidth, bottomImageheight);
-		}
-	}
-
-	async function drawOrderCard(data, ctx) {
-		const maxFieldsHeight = maxHeight * 0.455;
-		const textPosition = maxHeight * 0.54;
-		const marginOrderWidth = maxHeight * 0.1;
-
-		let interline = maxHeight * 0.0077;
-		let fontSize = maxHeight * 0.03;
-
-		// Load images from paths
-		const picture = await loadImage(data.picture);
-
-		if (!data.hasText) {
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-		} else {
-
-			// Initial settings for margin and font size
-			let generalTextHeight = 0;
-			const generalTextWithFbElements = replaceForbiddenStarsElements(data.general)
-			const recalculateTextHeight = () => {
-				generalTextHeight = calculateTextHeight(ctx, generalTextWithFbElements, 0, marginOrderWidth, interline, fontSize);
-			};
-
-			const resizeAllShit = () => {
-				fontSize *= 0.95;
-				interline *= 0.97;
-				recalculateTextHeight();
-			};
-
-			recalculateTextHeight()
-			while (generalTextHeight > maxFieldsHeight) {
-				resizeAllShit();
-			};
-
-			const drawText = (text, yPosition) => {
-				ctx.font = `${fontSize}px ForbiddenStars`;
-				const words = text.split(' ');
-				let line = '';
-				let lineHeight = parseInt(ctx.font.match(/\d+/), 10);
-				yPosition += lineHeight;
-				for (let n = 0; n < words.length; n++) {
-					if (words[n] === "*newline*") {
-						ctx.fillText(line, maxWidth * 0.5, yPosition);
-						yPosition += lineHeight + interline;
-						line = '';
-					}
-					else if (words[n] === "*newpara*") {
-						yPosition += 2 * lineHeight;
-						line = '';
-					}
-					else {
-						const testLine = line + words[n] + ' ';
-						const metrics = ctx.measureText(testLine);
-						if (metrics.width > maxWidth - 2 * marginOrderWidth && n > 0) {
-							ctx.fillText(line, maxWidth * 0.5, yPosition);
-							yPosition += lineHeight + interline;
-							line = words[n] + ' ';
-						} else {
-							line = testLine;
-						};
-					};
-				};
-				ctx.fillText(line, maxWidth * 0.5, yPosition);
-			};
-
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-			ctx.font = `${titleFontSize}px Headline`;
-			ctx.textAlign = "center";
-			ctx.fillText(data.title, maxWidth * 0.5, maxHeight * 0.2325);
-
-			drawText(generalTextWithFbElements, textPosition);
-		}
-	}
-
-	async function drawEventCard(data, ctx) {
-		const maxFieldsHeight = maxHeight * 0.278;
-		const textPosition = maxHeight * 0.685;
-
-		let interline = maxHeight * 0.0077;
-		let fontSize = maxHeight * 0.03;
-
-		// Load images from paths
-		const picture = await loadImage(data.picture);
-
-		if (!data.hasText) {
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-		} else {
-			// Initial settings for margin and font size
-			let generalTextHeight = 0;
-			const generalTextWithFbElements = replaceForbiddenStarsElements(data.general);
-			const recalculateTextHeight = () => {
-				generalTextHeight = calculateTextHeight(ctx, generalTextWithFbElements, 20, 0, interline, fontSize);
-			};
-			const resizeAllShit = () => {
-				fontSize *= 0.95;
-				interline *= 0.97;
-				recalculateTextHeight()
-			};
-			recalculateTextHeight()
-			while (generalTextHeight > maxFieldsHeight) {
-				resizeAllShit();
-			};
-			const drawText = (ctx_, text, yPosition) => {
-				ctx_.font = `${fontSize}px ForbiddenStars`;
-				const words = text.split(' ');
-				let line = '';
-				let lineHeight = parseInt(ctx_.font.match(/\d+/), 10);
-				yPosition += lineHeight;
-				for (let n = 0; n < words.length; n++) {
-					if (words[n] === "*newline*") {
-						ctx_.fillText(line, marginWidth, yPosition);
-						yPosition += lineHeight + interline;
-						line = '';
-					}
-					else if (words[n] === "*newpara*") {
-						ctx_.fillText(line, marginWidth, yPosition);
-						yPosition += 2 * lineHeight;
-						line = '';
-					}
-					else {
-						const testLine = line + words[n] + ' ';
-						const metrics = ctx_.measureText(testLine);
-						if (metrics.width > maxWidth - 2 * marginWidth && n > 0) {
-							ctx_.fillText(line, marginWidth, yPosition);
-							yPosition += lineHeight + interline;
-							line = words[n] + ' ';
-						} else {
-							line = testLine;
-						};
-					};
-				};
-				ctx_.fillText(line, marginWidth, yPosition);
-			};
-
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-			ctx.font = `${titleFontSize * 0.8}px EventFont`;
-			ctx.textAlign = "center";
-			ctx.fillText(data.type, maxWidth * 0.5, maxHeight * 0.573);
-			ctx.font = `${titleFontSize}px Headline`;
-			ctx.textAlign = "left";
-			ctx.fillText(data.title, maxWidth * 0.05, maxHeight * 0.0735);
-			drawText(ctx, generalTextWithFbElements, textPosition);
-		}
-	}
-});
+    return groups;
+  }
+
+  /* ---------------- lightbox ---------------- */
+
+  function openLb(idx) { setState({ lb: idx }); }
+  function closeLb() { setState({ lb: null }); }
+  function step(d) {
+    if (!flat.length || state.lb === null) return;
+    setState({ lb: (state.lb + d + flat.length) % flat.length });
+  }
+
+  document.addEventListener('keydown', function (e) {
+    if (state.lb === null) return;
+    if (e.key === 'Escape') closeLb();
+    else if (e.key === 'ArrowRight') step(1);
+    else if (e.key === 'ArrowLeft') step(-1);
+  });
+
+  /* ---------------- render ---------------- */
+
+  function render() {
+    var acc = ACC[ACCENT] || ACC.amber;
+    var cols = Math.max(2, Math.min(6, density()));
+    var cat = state.category;
+
+    var expObj = find(EXPANSIONS, state.expansion) || {};
+    var available = !!expObj.available;
+
+    var groups = build();
+
+    // grid geometry per category
+    var gridCols, gridJustify, cardAspect;
+    if (cat === 'faction_card') {
+      gridCols = 'repeat(1, minmax(0, 540px))'; gridJustify = 'center'; cardAspect = '1688 / 2000';
+    } else if (cat === 'map') {
+      gridCols = 'repeat(2, minmax(0, 1fr))'; gridJustify = 'start'; cardAspect = '1 / 1';
+    } else {
+      gridCols = 'repeat(' + cols + ', minmax(0, 1fr))'; gridJustify = 'start'; cardAspect = '434 / 615';
+    }
+
+    var app = el('div', { class: 'fs-app', 'data-accent': ACCENT });
+
+    /* ---- header ---- */
+    var exptabs = el('div', { class: 'fs-exptabs fs-scroll' },
+      EXPANSIONS.map(function (e) {
+        return el('button', {
+          class: 'fs-tab' + (state.expansion === e.key ? ' is-active' : ''),
+          onclick: function () { setState({ expansion: e.key, lb: null }); },
+        }, [
+          el('span', { text: e.name }),
+          !e.available ? el('span', { class: 'fs-tab-soon', text: 'SOON' }) : null,
+        ]);
+      })
+    );
+    var header = el('header', { class: 'fs-header' }, [
+      el('div', { class: 'fs-brand' }, [
+        el('div', { class: 'fs-logo' }, [
+          el('div', { class: 'fs-logo-ring' }),
+          el('div', { class: 'fs-logo-core' }),
+        ]),
+        el('div', { class: 'fs-brand-text' }, [
+          el('span', { class: 'fs-brand-title', text: 'FORBIDDEN STARS' }),
+          el('span', { class: 'fs-brand-sub', text: 'Card Codex' }),
+        ]),
+      ]),
+      exptabs,
+    ]);
+
+    /* ---- sidebar ---- */
+    var nav = el('nav', { class: 'fs-nav' },
+      FACTIONS.map(function (f) {
+        return el('button', {
+          class: 'fs-fac' + (state.faction === f.key ? ' is-active' : ''),
+          onclick: function () { setState({ faction: f.key, lb: null }); },
+        }, [
+          el('span', { class: 'fs-fac-dot', style: 'background:' + f.dot + ';' }),
+          el('span', { class: 'fs-fac-name', text: f.name }),
+          el('span', { class: 'fs-fac-count', text: '33' }),
+        ]);
+      })
+    );
+    var sidebar = el('aside', { class: 'fs-sidebar' }, [
+      el('div', { class: 'fs-sidebar-label', text: 'Factions' }),
+      nav,
+      el('div', { class: 'fs-sidebar-foot' }, [
+        el('a', { class: 'fs-faq-link', href: 'faq_manuscript_page.html', text: 'FAQ & Rules' }),
+        el('p', {
+          html: 'FAN PROJECT &middot; NON&#8209;COMMERCIAL<br>Artwork &copy; Games Workshop',
+        }),
+      ]),
+    ]);
+
+    /* ---- main ---- */
+    var main = el('main', { class: 'fs-main' });
+
+    if (available) {
+      var cattabs = el('div', { class: 'fs-cattabs fs-scroll' },
+        CATEGORIES.map(function (c) {
+          return el('button', {
+            class: 'fs-cat' + (cat === c.key ? ' is-active' : ''),
+            onclick: function () { setState({ category: c.key, lb: null }); },
+            text: c.name,
+          });
+        })
+      );
+      main.appendChild(el('div', { class: 'fs-cattabs-wrap' }, [cattabs]));
+
+      main.appendChild(el('div', { class: 'fs-breadcrumb' }, [
+        el('div', { class: 'fs-bc-left' }, [
+          el('span', { class: 'fs-bc-exp', text: expObj.name || '' }),
+          el('span', { class: 'fs-bc-sep', text: '/' }),
+          el('h1', { class: 'fs-bc-title', text: facName(state.faction) + ' — ' + catName(cat) }),
+        ]),
+        el('span', {
+          class: 'fs-bc-total',
+          text: flat.length + ' ' + (flat.length === 1 ? 'card' : 'cards'),
+        }),
+      ]));
+
+      var scrollarea = el('div', { class: 'fs-scrollarea fs-scroll' });
+      groups.forEach(function (group) {
+        if (group.label) {
+          scrollarea.appendChild(el('div', { class: 'fs-group-head' }, [
+            el('span', { class: 'fs-group-label', text: group.label }),
+            el('span', { class: 'fs-group-rule' }),
+            el('span', { class: 'fs-group-sub', text: group.sub }),
+          ]));
+        }
+        var grid = el('div', {
+          class: 'fs-grid',
+          style: 'grid-template-columns:' + gridCols + ';justify-content:' + gridJustify + ';',
+        }, group.cards.map(function (card) {
+          return el('button', {
+            class: 'fs-card',
+            title: card.label,
+            style: 'aspect-ratio:' + cardAspect + ';',
+            onclick: (function (idx) { return function () { openLb(idx); }; })(card.index),
+          }, [
+            el('img', { src: card.src, alt: card.label, loading: 'lazy' }),
+          ]);
+        }));
+        scrollarea.appendChild(grid);
+      });
+      main.appendChild(scrollarea);
+    } else {
+      main.appendChild(el('div', { class: 'fs-empty' }, [
+        el('div', { class: 'fs-empty-glyph' }, [
+          el('div', { class: 'ring' }),
+          el('div', { class: 'core' }),
+        ]),
+        el('div', { class: 'fs-empty-stack' }, [
+          el('h2', { text: expObj.name || '' }),
+          el('p', {
+            html: 'Artwork for this expansion isn&rsquo;t bundled in this build. ' +
+              'The full Base Game codex &mdash; four factions, every card &mdash; is ready to browse.',
+          }),
+        ]),
+        el('button', {
+          class: 'fs-empty-btn',
+          text: 'View Base Game',
+          onclick: function () { setState({ expansion: 'base' }); },
+        }),
+      ]));
+    }
+
+    app.appendChild(header);
+    app.appendChild(el('div', { class: 'fs-body' }, [sidebar, main]));
+
+    /* ---- lightbox ---- */
+    var lbOpen = state.lb !== null && available;
+    if (lbOpen) {
+      var c = flat[state.lb];
+      if (c) {
+        var overlay = el('div', { class: 'fs-lb', onclick: closeLb }, [
+          el('button', {
+            class: 'fs-lb-nav', 'aria-label': 'Previous card', html: '&lsaquo;',
+            onclick: function (e) { e.stopPropagation(); step(-1); },
+          }),
+          el('figure', { class: 'fs-lb-fig', onclick: function (e) { e.stopPropagation(); } }, [
+            el('img', { src: c.src, alt: c.label }),
+            el('figcaption', { class: 'fs-lb-cap' }, [
+              el('span', { class: 'fs-lb-label', text: c.label }),
+              el('span', {
+                class: 'fs-lb-meta',
+                text: catName(cat) + ' · ' + facName(state.faction) + ' · ' + (state.lb + 1) + ' / ' + flat.length,
+              }),
+            ]),
+          ]),
+          el('button', {
+            class: 'fs-lb-nav', 'aria-label': 'Next card', html: '&rsaquo;',
+            onclick: function (e) { e.stopPropagation(); step(1); },
+          }),
+          el('button', {
+            class: 'fs-lb-close', 'aria-label': 'Close', html: '&#10005;',
+            onclick: function (e) { e.stopPropagation(); closeLb(); },
+          }),
+        ]);
+        app.appendChild(overlay);
+      }
+    }
+
+    var root = document.getElementById('app');
+    root.innerHTML = '';
+    root.appendChild(app);
+  }
+
+  // Re-render on resize (debounced) so the column count tracks the viewport.
+  var _rt;
+  window.addEventListener('resize', function () {
+    clearTimeout(_rt);
+    _rt = setTimeout(render, 120);
+  });
+
+  /* ---------------- boot ---------------- */
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', render);
+  } else {
+    render();
+  }
+})();

--- a/page/style/styles.css
+++ b/page/style/styles.css
@@ -1,438 +1,300 @@
-@font-face {
-    font-family: 'Headline';
-    src: url('../fonts/Headline.woff2') format('woff2');
-}
+/* Forbidden Stars — Card Codex
+   Ported from the "Forbidden Stars Codex" Claude Design component.
+   Pure static CSS, no build step. Desktop-first 100vh app shell. */
 
-@font-face {
-    font-family: 'ForbiddenStars';
-    src: url('../fonts/ForbiddenStars.woff2') format('woff2');
-}
+* { box-sizing: border-box; }
 
-@font-face {
-    font-family: 'EventFont';
-    src: url('../fonts/EventFont.woff2') format('woff2');
-}
-
-:root {
-  --text:#bbb;
-  --text_2:#222;
-  --text_3: #000;
-  --background:#999;
-  --background_2:#222;
-  --background_3:#777;
-  --highlight: #aa6;
-  --spinnerColor: #36f;
-  --blue:rgba(47, 95, 255, 0.5);
-  --border:1px solid rgba(0, 0, 100, 0.5);
-  --max-width:1040px;
-  --content-width:940px;
+html, body {
+  margin: 0;
+  padding: 0;
+  background: #121110;
 }
 
 body {
-    top: 0;
-    display: flex;
-    flex-direction: column;
-    font-family: 'Headline';
-    width: 1420px;
-    min-height: 100vh;
-    gap: 5px;
-    color: var(--text);
-    background: var(--background);
+  color: #ece8e1;
+  font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
+::selection { background: rgba(216, 166, 87, 0.28); }
 
-@keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
+/* ---- scrollbars ---- */
+.fs-scroll::-webkit-scrollbar { width: 10px; height: 10px; }
+.fs-scroll::-webkit-scrollbar-thumb {
+  background: #2c2925;
+  border-radius: 8px;
+  border: 2px solid #121110;
+}
+.fs-scroll::-webkit-scrollbar-thumb:hover { background: #3a3631; }
+.fs-scroll::-webkit-scrollbar-track { background: transparent; }
 
-    100% {
-        transform: rotate(360deg);
-    }
+/* ---- animations ---- */
+@keyframes fsfade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes fspop  { from { opacity: 0; transform: scale(.965); } to { opacity: 1; transform: scale(1); } }
+
+/* ---- accent themes (set via [data-accent] on .fs-app) ---- */
+.fs-app {
+  --fs-accent: oklch(0.80 0.12 80);
+  --fs-accent-fg: #1c1810;
+}
+.fs-app[data-accent="amber"]   { --fs-accent: oklch(0.80 0.12 80);  --fs-accent-fg: #1c1810; }
+.fs-app[data-accent="steel"]   { --fs-accent: oklch(0.72 0.10 232); --fs-accent-fg: #0b1019; }
+.fs-app[data-accent="crimson"] { --fs-accent: oklch(0.62 0.185 25); --fs-accent-fg: #1c0d0c; }
+
+/* ---- app shell ---- */
+.fs-app {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: #121110;
+  color: #ece8e1;
+  overflow: hidden;
 }
 
-.card-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-family: 'EventFont';
-    width: 450px;
-    height: 650px;
-    color: var(--text);
-    font-size: 25px;
-    background-color: var(--background_2);
-    border-radius: 8px;
+/* ---- header ---- */
+.fs-header {
+  display: flex;
+  align-items: center;
+  gap: 26px;
+  padding: 0 22px;
+  height: 60px;
+  border-bottom: 1px solid #2c2925;
+  background: #16140f;
+  flex-shrink: 0;
+  z-index: 10;
+}
+.fs-brand { display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
+.fs-logo { position: relative; width: 24px; height: 24px; flex-shrink: 0; }
+.fs-logo-ring {
+  position: absolute; inset: 2px; transform: rotate(45deg);
+  border: 1.5px solid var(--fs-accent); border-radius: 3px;
+}
+.fs-logo-core {
+  position: absolute; left: 50%; top: 50%; width: 6px; height: 6px;
+  margin: -3px 0 0 -3px; background: var(--fs-accent); transform: rotate(45deg);
+}
+.fs-brand-text { display: flex; flex-direction: column; line-height: 1.1; }
+.fs-brand-title { font-size: 14.5px; font-weight: 700; letter-spacing: 0.16em; }
+.fs-brand-sub {
+  font-family: 'IBM Plex Mono', monospace; font-size: 9px; letter-spacing: 0.34em;
+  color: #857f74; text-transform: uppercase; margin-top: 2px;
 }
 
-.card-placeholder .card-spinner {
-    border: var(--border);
-    border-top: 4px solid var(--spinnerColor);
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    animation: spin 1s linear infinite;
+.fs-exptabs {
+  display: flex; align-items: center; gap: 3px;
+  overflow-x: auto; margin-left: 4px;
 }
 
-#expansion-tabs {
-    font-size: 30px;
-    width: 100%;
+/* ---- generic tab (expansion bar) ---- */
+.fs-tab {
+  appearance: none; border: none; cursor: pointer; font-family: inherit;
+  font-size: 12.5px; font-weight: 500; letter-spacing: 0.01em;
+  padding: 7px 13px; border-radius: 8px; white-space: nowrap;
+  display: inline-flex; align-items: center;
+  background: transparent; color: #8a847a;
+  transition: background .15s, color .15s;
+}
+.fs-tab:hover { color: #c4bdb1; }
+.fs-tab.is-active {
+  font-weight: 600; background: var(--fs-accent); color: var(--fs-accent-fg);
+}
+.fs-tab-soon {
+  margin-left: 8px; font-family: 'IBM Plex Mono', monospace; font-size: 8px;
+  letter-spacing: 0.12em; opacity: 0.55;
 }
 
-#faction-tabs {
-    font-size: 28px;
-    width: 100%;
+/* ---- body row ---- */
+.fs-body { flex: 1; display: flex; min-height: 0; }
+
+/* ---- sidebar ---- */
+.fs-sidebar {
+  width: 236px; flex-shrink: 0; border-right: 1px solid #2c2925;
+  background: #16140f; display: flex; flex-direction: column; padding: 18px 14px;
+}
+.fs-sidebar-label {
+  font-family: 'IBM Plex Mono', monospace; font-size: 10px; letter-spacing: 0.26em;
+  color: #857f74; text-transform: uppercase; padding: 0 8px 12px;
+}
+.fs-nav { display: flex; flex-direction: column; gap: 3px; }
+
+.fs-fac {
+  display: flex; align-items: center; gap: 11px; width: 100%; text-align: left;
+  appearance: none; border: 1px solid transparent; background: transparent;
+  cursor: pointer; font-family: inherit; color: #b3ada3; font-size: 13.5px;
+  font-weight: 500; padding: 9px 11px; border-radius: 10px; transition: all .15s;
+}
+.fs-fac:hover { background: #1d1b18; }
+.fs-fac.is-active {
+  border: 1px solid #34302a; background: #221f1a; color: #f3efe8; font-weight: 600;
+  box-shadow: inset 2px 0 0 var(--fs-accent);
+}
+.fs-fac-dot {
+  width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.035);
+}
+.fs-fac-name { flex: 1; }
+.fs-fac-count { font-family: 'IBM Plex Mono', monospace; font-size: 10px; color: #6f6a61; }
+
+.fs-sidebar-foot {
+  margin-top: auto; padding: 14px 8px 2px; border-top: 1px solid #221f1a;
+}
+.fs-sidebar-foot p {
+  font-family: 'IBM Plex Mono', monospace; font-size: 9px; line-height: 1.7;
+  color: #5c574f; margin: 0; letter-spacing: 0.05em;
+}
+.fs-faq-link {
+  display: inline-block; margin-bottom: 10px;
+  font-family: 'IBM Plex Mono', monospace; font-size: 10px; letter-spacing: 0.18em;
+  text-transform: uppercase; color: #857f74; text-decoration: none;
+  transition: color .15s;
+}
+.fs-faq-link:hover { color: var(--fs-accent); }
+
+/* ---- main ---- */
+.fs-main { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+
+.fs-cattabs-wrap {
+  padding: 0 26px; border-bottom: 1px solid #2c2925; background: #141310; flex-shrink: 0;
+}
+.fs-cattabs { display: flex; gap: 2px; overflow-x: auto; }
+.fs-cat {
+  appearance: none; border: none; background: transparent; cursor: pointer;
+  font-family: inherit; font-size: 13px; font-weight: 500; color: #8a847a;
+  padding: 13px 15px; border-bottom: 2px solid transparent; white-space: nowrap;
+  transition: color .15s, border-color .15s;
+}
+.fs-cat:hover { color: #c4bdb1; }
+.fs-cat.is-active {
+  font-weight: 600; color: #f3efe8; border-bottom: 2px solid var(--fs-accent);
 }
 
-#cards-tabs {
-    font-size: 26px;
-    width: 100%;
+.fs-breadcrumb {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  padding: 17px 26px 5px; flex-shrink: 0;
+}
+.fs-bc-left { display: flex; align-items: center; gap: 11px; min-width: 0; }
+.fs-bc-exp {
+  font-family: 'IBM Plex Mono', monospace; font-size: 10px; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--fs-accent); white-space: nowrap;
+}
+.fs-bc-sep { color: #3a352f; }
+.fs-bc-title {
+  font-size: 16px; font-weight: 600; margin: 0; color: #f3efe8;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.fs-bc-total {
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #857f74;
+  letter-spacing: 0.08em; white-space: nowrap;
 }
 
-.expansion-header,
-.faction-header,
-.card-header {
-    border-radius:12px;
-    display: inline-block;
-    padding: 5px 8px 8px 8px;
-    background-color: var(--background_2);
-    z-index: 1000;
-    cursor: grab;
-    letter-spacing: .01em;
-    margin: 1px;
+.fs-scrollarea { flex: 1; min-height: 0; overflow-y: auto; padding: 18px 26px 44px; }
+
+.fs-group-head { display: flex; align-items: center; gap: 13px; margin: 8px 0 16px; }
+.fs-group-label {
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px; font-weight: 500;
+  letter-spacing: 0.18em; text-transform: uppercase; color: #bdb7ac; white-space: nowrap;
+}
+.fs-group-rule { height: 1px; flex: 1; background: linear-gradient(90deg, #2c2925, transparent); }
+.fs-group-sub {
+  font-family: 'IBM Plex Mono', monospace; font-size: 10px; color: #6f6a61; white-space: nowrap;
 }
 
-.expansion-header.active,
-.faction-header.active {
-    background-color: var(--background_3);
-    color: var(--text_2);
-    box-shadow: 0 0 30px #f80;
-    cursor: default;
+.fs-grid { display: grid; gap: 18px; margin-bottom: 30px; }
+
+.fs-card {
+  appearance: none; padding: 0; margin: 0; cursor: zoom-in; background: #1e1c1a;
+  border: 1px solid #2c2925; border-radius: 12px; overflow: hidden; width: 100%;
+  display: block; position: relative;
+  transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease;
 }
-
-.card-header.active {
-    background-color: var(--background_3);
-    box-shadow: 0 0 10px #090;
-    color: var(--text_2);
-    cursor: default;
+.fs-card:hover {
+  border-color: var(--fs-accent); transform: translateY(-5px);
+  box-shadow: 0 14px 34px -10px rgba(0, 0, 0, .78);
 }
+.fs-card img { width: 100%; height: 100%; object-fit: cover; display: block; }
 
-.card-container {
-    display: none;
+/* ---- unavailable state ---- */
+.fs-empty {
+  flex: 1; display: flex; flex-direction: column; align-items: center;
+  justify-content: center; gap: 18px; padding: 40px; text-align: center;
 }
-
-.card-container.active {
-    display: block;
+.fs-empty-glyph { position: relative; width: 54px; height: 54px; opacity: 0.85; }
+.fs-empty-glyph .ring {
+  position: absolute; inset: 4px; transform: rotate(45deg);
+  border: 1.5px solid #3a3631; border-radius: 6px;
 }
-
-#faq-container {
-    display: none;
-    width: 100%;
-    position: relative;
-    flex: 1;
+.fs-empty-glyph .core {
+  position: absolute; left: 50%; top: 50%; width: 12px; height: 12px;
+  margin: -6px 0 0 -6px; background: #2c2925; transform: rotate(45deg);
 }
-
-#faq-container.active {
-    display: flex;
-    flex-direction: column;
+.fs-empty-stack { display: flex; flex-direction: column; gap: 7px; align-items: center; }
+.fs-empty h2 {
+  font-size: 19px; font-weight: 600; margin: 0; color: #e6e1d8; letter-spacing: 0.01em;
 }
-
-.faq-page-shell {
-    position: relative;
-    width: 100%;
-    min-height: 100vh;
-    color: var(--text_2);
+.fs-empty p {
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px; line-height: 1.8;
+  color: #7a746a; margin: 0; max-width: 380px; letter-spacing: 0.03em;
 }
-
-.faq-header-panel {
-    position: sticky;
-    top: 12px;
-    z-index: 20;
-    max-width: var(--max-width);
-    margin: 0 auto 24px;
-    padding: 14px;
-    background-color: var(--background_2);
-    color: var(--text);
-    border-radius: 18px;
-    opacity: 0.85;
+.fs-empty-btn {
+  appearance: none; cursor: pointer; font-family: inherit; font-size: 12.5px;
+  font-weight: 600; letter-spacing: 0.02em; color: var(--fs-accent-fg);
+  background: var(--fs-accent); border: none; border-radius: 9px; padding: 10px 18px;
+  transition: opacity .15s;
 }
+.fs-empty-btn:hover { opacity: 0.9; }
 
-.faq-search-wrap {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    flex-wrap: wrap;
+/* ---- lightbox ---- */
+.fs-lb {
+  position: fixed; inset: 0; z-index: 60; background: rgba(8, 7, 6, .88);
+  backdrop-filter: blur(7px); -webkit-backdrop-filter: blur(7px);
+  display: flex; align-items: center; justify-content: center; gap: 18px;
+  padding: 32px; animation: fsfade .18s ease;
 }
-
-.faq-search-box {
-    flex: 1 1 340px;
-    min-width: 260px;
-    padding: 14px 18px;
-    border-radius: 12px;
-    border: var(--border);
-    background-color: var(--background);
-    font-size: 16px;
-    font-family: 'ForbiddenStars';
-    outline: none;
+.fs-lb-nav {
+  width: 46px; height: 46px; flex-shrink: 0; border-radius: 50%;
+  border: 1px solid #38332c; background: rgba(30, 28, 26, .85); color: #d8d2c8;
+  font-size: 24px; line-height: 1; cursor: pointer; display: flex;
+  align-items: center; justify-content: center; transition: all .15s;
 }
-
-.faq-search-meta {
-    font-size: 14px;
-    border-radius: 12px;
-    font-family: 'ForbiddenStars';
+.fs-lb-nav:hover { border-color: var(--fs-accent); color: var(--fs-accent); }
+.fs-lb-fig {
+  margin: 0; display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: fspop .2s ease;
 }
-
-.faq-content {
-    position: relative;
-    max-width: var(--content-width);
-    margin: 0 auto;
-    padding: 50px 30px 200px 15px;
-    border-radius: 24px;
-    overflow: hidden;
+.fs-lb-fig img {
+  max-height: 80vh; max-width: min(640px, 80vw); border-radius: 14px;
+  border: 1px solid #38332c; box-shadow: 0 40px 90px -25px #000; display: block;
 }
-
-.faq-empty-state {
-    padding: 24px 0;
-    font-size: 18px;
-    text-align: center;
-    opacity: 0.8;
+.fs-lb-cap { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+.fs-lb-label { font-size: 15px; font-weight: 600; color: #f3efe8; }
+.fs-lb-meta {
+  font-family: 'IBM Plex Mono', monospace; font-size: 10.5px; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--fs-accent);
 }
-
-.faq-level-block {
-    margin: 0 0 28px;
+.fs-lb-close {
+  position: absolute; top: 22px; right: 24px; width: 38px; height: 38px;
+  border-radius: 50%; border: 1px solid #38332c; background: rgba(30, 28, 26, .85);
+  color: #b3ada3; font-size: 15px; line-height: 1; cursor: pointer; display: flex;
+  align-items: center; justify-content: center; transition: all .15s;
 }
+.fs-lb-close:hover { border-color: var(--fs-accent); color: #f3efe8; }
 
-.faq-level-row {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(180px, 280px);
-    gap: 18px;
-    align-items: start;
+/* ---- responsive ---- */
+@media (max-width: 900px) {
+  .fs-sidebar { width: 188px; }
 }
-
-.faq-level-row.no-picture {
-    grid-template-columns: 1fr;
-}
-
-.faq-level-image {
-    max-width: 100px;
-    border-radius: 10px;
-    border: var(--border);
-    display: block;
-    justify-self: end;
-}
-
-.faq-content h1,
-.faq-content h2,
-.faq-content h3 {
-    margin: 0;
-    line-height: 1.15;
-    font-family: 'EventFont';
-    letter-spacing: 0.01em;
-}
-
-.faq-phrase-title,
-.faq-main-text {
-    font-family: 'ForbiddenStars';
-}
-
-.faq-content h1 {
-    font-size: clamp(30px, 4vw, 44px);
-    margin-bottom: 10px;
-}
-
-.faq-content h2 {
-    font-size: clamp(24px, 3vw, 34px);
-    margin-bottom: 8px;
-}
-
-.faq-content h3 {
-    font-size: clamp(22px, 2.8vw, 30px);
-    margin-bottom: 8px;
-}
-
-.faq-separator {
-    width: 100%;
-    height: 3px;
-    background: linear-gradient(to right, transparent, var(--blue), transparent);
-    margin: 0 0 16px;
-}
-
-.faq-category-block {
-    margin-bottom: 42px;
-}
-
-.faq-subcategory-block {
-    margin: 22px 0 28px;
-    padding-left: 10px;
-}
-
-.faq-faction-block {
-    margin: 18px 0 24px;
-    padding-left: 12px;
-}
-
-.faq-phrase-block {
-    margin: 14px 0 16px;
-    padding: 14px 16px;
-    border-radius: 14px;
-    background: var(--background);
-    border: var(--border);
-}
-
-.faq-phrase-title {
-    display: block;
-    font-weight: 700;
-    font-size: 18px;
-    margin-bottom: 8px;
-    color: var(--text_3);
-}
-
-.faq-main-text {
-    font-size: 17px;
-    line-height: 1.7;
-    white-space: pre-wrap;
-    word-break: break-word;
-}
-
-.faq-content mark {
-    background: var(--highlight);
-    color: inherit;
-    padding: 0 0.1em;
-    border-radius: 0.15em;
-}
-
-.grid {
-    display: grid;
-    gap: 20px 20px;
-    grid-template-columns: repeat(3, 1fr);
-    background-color: var(--background_3);
-    gap: 5px 5px;
-    padding: 10px;
-}
-
-.grid.events {
-    grid-template-columns: repeat(4, 1fr);
-    width: 1835px;
-}
-
-.grid.cardBackImages {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 5px 5px;
-}
-
-.grid.factionCardImage {
-    grid-template-columns: repeat(1, 1fr);
-    width: 1835px;
-}
-
-.grid.mapImages {
-    grid-template-columns: repeat(2, 1fr);
-    width: 1835px;
-}
-
-
-.grid.orders {
-    grid-template-columns: repeat(3, 1fr);
-}
-
-.grid.combat.s-section {
-    background-color: #090;
-}
-
-.grid.combat.t1-section {
-    background-color: #990;
-}
-
-.grid.combat.t2-section {
-    background-color: #950;
-}
-
-.grid.combat.t3-section {
-    background-color: #900;
-}
-
-.faction-header.active[data-faction="space_marines"] {
-    background-color: #66f;
-    box-shadow: 0 0 5px #66f;
-}
-
-.faction-header.active[data-faction="chaos"] {
-    background-color: #e11;
-    box-shadow: 0 0 5px #f55;
-}
-
-.faction-header.active[data-faction="ork"] {
-    background-color: #2f3;
-    box-shadow: 0 0 5px #2f4;
-}
-
-.faction-header.active[data-faction="eldar"] {
-    background-color: #ff1;
-    box-shadow: 0 0 5px #ff1;
-}
-
-.faction-header.active[data-faction="ig"] {
-    background-color: #999;
-    color: #050;
-    box-shadow: 0 0 5px #ccc;
-}
-
-.faction-header.active[data-faction="tyranid"] {
-    background-color: #b3f;
-    box-shadow: 0 0 5px #c4f;
-}
-
-.faction-header.active[data-faction="necron"] {
-    background-color: #000;
-    color: #2f1;
-    box-shadow: 0 0 5px #2f1;
-}
-
-.faction-header.active[data-faction="tau"] {
-    background-color: #fa1;
-    box-shadow: 0 0 5px #fa1;
-}
-
-.faction-header.active[data-faction="adeptus_mechanicus"] {
-    background-color: #a52;
-    box-shadow: 0 0 5px #a52;
-}
-
-.faction-header.active[data-faction="adepta_sororitas"] {
-    background-color: #fff;
-    box-shadow: 0 0 5px #fff;
-    color: #000;
-}
-
-.faction-header.active[data-faction="dark_eldar"] {
-    background-color: #1ed;
-    box-shadow: 0 0 5px #1ed;
-    color: #000;
-}
-
-.faction-header.active[data-faction="inquisition"] {
-    background-color: #80f;
-    box-shadow: 0 0 5px #80f;
-    color: #fff;
-}
-
-.faction-header.active[data-faction="worldeaters"] {
-    background-color: #f33;
-    box-shadow: 0 0 5px #f55;
-}
-
-.faction-header.active[data-faction="thousandsons"] {
-    background-color: #22f;
-    color: #cc2;
-    box-shadow: 0 0 5px #22f;
-}
-
-.faction-header.active[data-faction="emperorschildren"] {
-    background-color: #d2a;
-    box-shadow: 0 0 5px #d2a;
-}
-
-.faction-header.active[data-faction="deathguard"] {
-    background-color: #351;
-    color: #aa0;
-    box-shadow: 0 0 5px #351;
+@media (max-width: 720px) {
+  .fs-app { height: auto; min-height: 100vh; overflow: visible; }
+  .fs-body { flex-direction: column; }
+  .fs-sidebar {
+    width: 100%; border-right: none; border-bottom: 1px solid #2c2925;
+    flex-direction: row; flex-wrap: wrap; align-items: center; gap: 8px; padding: 12px 14px;
+  }
+  .fs-sidebar-label { display: none; }
+  .fs-nav { flex-direction: row; flex-wrap: wrap; flex: 1; }
+  .fs-fac { width: auto; }
+  .fs-fac-count { display: none; }
+  .fs-sidebar-foot { display: none; }
+  .fs-scrollarea { overflow-y: visible; }
+  .fs-header { gap: 14px; padding: 0 14px; }
+  .fs-grid { gap: 12px; }
 }


### PR DESCRIPTION
Port the "Forbidden Stars Codex" design into the static site as a vanilla HTML/CSS/JS single-page card browser, replacing the previous codex UI.

- index.html: minimal shell — IBM Plex fonts, favicons, #app mount
- styles.css: full design port — accent themes (amber/steel/crimson), faction sidebar, expansion/category tabs, grouped card grid, lightbox, responsive layout
- script.js: tiny state store + renderer; grouped grid (combat tiers), click-to-zoom lightbox with prev/next + Esc/arrow keyboard nav, and an empty state for unbundled expansions
- image paths adapted to repo layout factions/<exp>/<faction>/<folder>/<file>
- FAQ access preserved via sidebar link