### PR TITLE
Redesigned Card Codex — all expansions, card text, unit counts

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -4,30 +4,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Forbidden Star - Fan Factions</title>
-    <link rel="stylesheet" href="style\styles.css">
-    <link rel="apple-touch-icon" sizes="180x180" href="\apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="\favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="\favicon-16x16.png">
-    <link rel="manifest" href="page\site.webmanifest">
+    <title>Forbidden Stars — Card Codex</title>
+    <meta name="description" content="An online library of Forbidden Stars boardgame cards — browse every faction's combat, order, event and map cards.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="style/styles.css">
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
+    <link rel="manifest" href="site.webmanifest">
 </head>
 
 <body>
-    <div id="expansion-tabs"></div>
-    <div id="faction-tabs"></div>
-    <div id="cards-tabs"></div>
-    <div id="cards-container"></div>
-    <div id="faq-container" class="faq-container">
-        <div class="faq-page-shell">
-            <div class="faq-header-panel">
-                <div class="faq-search-wrap">
-                    <input id="faq-search-input" class="faq-search-box" type="text" placeholder="Search the FAQ..." />
-                    <div id="faq-search-meta" class="faq-search-meta">Showing full FAQ</div>
-                </div>
-            </div>
-            <main id="faq-content" class="faq-content" aria-live="polite"></main>
-        </div>
-    </div>
+    <div id="app"></div>
+    <script src="script/cardrender.js"></script>
     <script src="script/script.js"></script>
 </body>
 

--- a/page/script/cardrender.js
+++ b/page/script/cardrender.js
@@ -1,0 +1,369 @@
+/* Forbidden Stars — card text compositor.
+ *
+ * Some expansions (e.g. Symphony of War) ship card art as TEMPLATES with blank
+ * title/text areas; the card wording lives in the faction's text.json. This
+ * module draws that text onto the template via canvas — using the game's custom
+ * fonts and icon glyphs — and returns a composited image as a data URL.
+ *
+ * The drawing routines are ported verbatim from the original site renderer so
+ * the output matches the long-standing layout pixel-for-pixel.
+ *
+ * Public API:  window.FSCardRender.compose({ picture, kind, text }) -> Promise<string dataURL>
+ *   kind: 'combat' | 'orders' | 'events'
+ *   text (combat):  { title, background, foreground, icons }
+ *   text (orders):  { title, general }
+ *   text (events):  { title, general, type }
+ */
+(function () {
+  'use strict';
+
+  // Size of cards — everything else is derived from this.
+  var maxWidth = 450;
+  var maxHeight = 650;
+
+  // Size of boxes for combat cards.
+  var textBackgroundSize = 759;
+  var textBottomBarHeight = 18;
+  var textBottomBarWidth = 454;
+
+  var titleFontSize = maxHeight * 0.05;
+  var marginWidth = maxWidth * 0.0578;
+  var maxTextWidth = maxWidth - 2 * marginWidth;
+
+  // Icon positioning (combat unit icons).
+  var iconSize = maxWidth * 0.097;
+  var iconSpacing = maxWidth * 0.011;
+  var iconX = maxWidth * 0.0632;
+  var startY = maxHeight * 0.242;
+
+  var iconMap = {
+    'B': 'pictures/bolter.png',
+    'S': 'pictures/shield.png',
+    'M': 'pictures/moral.png',
+  };
+
+  function replaceForbiddenStarsElements(str) {
+    str = str.replace(/\[B\]/g, '}');
+    str = str.replace(/\[S\]/g, '{');
+    str = str.replace(/\[M\]/g, '<');
+    str = str.replace(/\[D\]/g, '|');
+    str = str.replace(/\(B\)/g, '#');
+    str = str.replace(/\(S\)/g, '@');
+    return str;
+  }
+
+  function calculateTextHeight(context, text, extraHeight, marginHeight, interline, fontSize) {
+    context.font = fontSize + 'px ForbiddenStars';
+    var words = text.split(' ');
+    var line = '';
+    var lineHeight = parseInt(context.font.match(/\d+/), 10);
+    var returnHeight = 0;
+    for (var n = 0; n < words.length; n++) {
+      if (words[n] === '*newline*') {
+        returnHeight += lineHeight + interline;
+        line = '';
+      } else if (words[n] === '*newpara*') {
+        returnHeight += 2 * lineHeight;
+        line = '';
+      } else {
+        var testLine = line + words[n] + ' ';
+        var metrics = context.measureText(testLine);
+        if (metrics.width > maxTextWidth && n > 0) {
+          returnHeight += lineHeight + interline;
+          line = words[n] + ' ';
+        } else {
+          line = testLine;
+        }
+      }
+    }
+    returnHeight += lineHeight * 2 + extraHeight + marginHeight * 2;
+    return returnHeight;
+  }
+
+  // image cache so shared chrome (background/foreground/bottom/icons) loads once
+  var _imgCache = {};
+  function loadImage(url) {
+    if (_imgCache[url]) return _imgCache[url];
+    _imgCache[url] = new Promise(function (resolve, reject) {
+      var img = new Image();
+      img.src = url;
+      img.onload = function () { resolve(img); };
+      img.onerror = function () { reject(new Error('Failed to load image ' + url)); };
+    });
+    return _imgCache[url];
+  }
+
+  async function drawCombatCard(data, ctx) {
+    var bottomImageheight = maxHeight * 0.025;
+    var maxFieldsHeight = maxHeight * 0.4;
+    var extraForegroundTriangle = maxHeight * 0.0455;
+    var extraBackgroundborder = maxHeight * 0.0385;
+
+    var interline = maxHeight * 0.0077;
+    var marginHeight = maxWidth * 0.05;
+    var fontSize = maxHeight * 0.03;
+
+    var picture = await loadImage(data.picture);
+    var background = await loadImage('pictures/background.png');
+    var foreground = await loadImage('pictures/foreground.png');
+    var bottomImage = await loadImage('pictures/bottom.png');
+
+    var backgroundTextHeight = 0;
+    var foregroundTextHeight = 0;
+
+    var backgroundWithFbElements = replaceForbiddenStarsElements(data.background);
+    var foregroundWithFbElements = replaceForbiddenStarsElements(data.foreground);
+
+    var recalculateTextHeight = function () {
+      if (data.background.length > 0) {
+        backgroundTextHeight = calculateTextHeight(ctx, backgroundWithFbElements, extraBackgroundborder, marginHeight, interline, fontSize);
+      }
+      if (data.foreground.length > 0) {
+        foregroundTextHeight = calculateTextHeight(ctx, foregroundWithFbElements, extraForegroundTriangle, marginHeight, interline, fontSize);
+      }
+    };
+    recalculateTextHeight();
+
+    var resizeCardText = function () {
+      marginHeight *= 0.8;
+      fontSize *= 0.99;
+      interline *= 0.95;
+      recalculateTextHeight();
+    };
+
+    if (data.background.length > 0 && data.foreground.length > 0) {
+      while ((backgroundTextHeight + foregroundTextHeight) > maxFieldsHeight) { resizeCardText(); }
+    } else {
+      while (Math.max(backgroundTextHeight, foregroundTextHeight) > maxFieldsHeight) { resizeCardText(); }
+    }
+
+    var drawText = function (text, yPosition, extra) {
+      ctx.font = fontSize + 'px ForbiddenStars';
+      var words = text.split(' ');
+      var line = '';
+      var lineHeight = parseInt(ctx.font.match(/\d+/), 10);
+      yPosition += marginHeight + extra + lineHeight;
+      for (var n = 0; n < words.length; n++) {
+        if (words[n] === '*newline*') {
+          ctx.fillText(line, marginWidth, yPosition);
+          yPosition += lineHeight + interline;
+          line = '';
+        } else if (words[n] === '*newpara*') {
+          ctx.fillText(line, marginWidth, yPosition);
+          yPosition += 2 * lineHeight;
+          line = '';
+        } else {
+          var testLine = line + words[n] + ' ';
+          var metrics = ctx.measureText(testLine);
+          if (metrics.width > maxWidth - 2 * marginWidth && n > 0) {
+            ctx.fillText(line, marginWidth, yPosition);
+            yPosition += lineHeight + interline;
+            line = words[n] + ' ';
+          } else {
+            line = testLine;
+          }
+        }
+      }
+      ctx.fillText(line, marginWidth, yPosition);
+    };
+
+    var drawImageCropped = function (img, height) {
+      ctx.drawImage(img, 0, 0, textBackgroundSize, maxHeight - height, 0, height, maxWidth, maxHeight - height);
+    };
+
+    ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
+    ctx.font = titleFontSize + 'px Headline';
+    ctx.fillText(data.title, maxWidth * 0.27, maxHeight * 0.077);
+
+    if (data.background.length > 0) {
+      var backgroundY = maxHeight - (backgroundTextHeight + foregroundTextHeight);
+      drawImageCropped(background, backgroundY);
+      drawText(backgroundWithFbElements, backgroundY, extraBackgroundborder);
+    }
+    if (data.foreground.length > 0) {
+      var foregroundY = maxHeight - (foregroundTextHeight + extraForegroundTriangle * 0.35);
+      drawImageCropped(foreground, foregroundY);
+      drawText(foregroundWithFbElements, foregroundY, extraForegroundTriangle);
+    }
+    if (data.icons && data.icons.length > 0) {
+      var currentY = startY;
+      for (var letterPosition = 0; letterPosition < data.icons.length; letterPosition++) {
+        var iconChar = data.icons[letterPosition].toUpperCase();
+        if (iconMap[iconChar]) {
+          var iconImg = await loadImage(iconMap[iconChar]);
+          ctx.drawImage(iconImg, iconX, currentY, iconSize, iconSize);
+          currentY += iconSize + iconSpacing;
+        }
+      }
+    }
+    ctx.drawImage(bottomImage, 0, 0, textBottomBarWidth, textBottomBarHeight, 0, maxHeight - bottomImageheight, maxWidth, bottomImageheight);
+  }
+
+  async function drawOrderCard(data, ctx) {
+    var maxFieldsHeight = maxHeight * 0.455;
+    var textPosition = maxHeight * 0.54;
+    var marginOrderWidth = maxHeight * 0.1;
+
+    var interline = maxHeight * 0.0077;
+    var fontSize = maxHeight * 0.03;
+
+    var picture = await loadImage(data.picture);
+
+    var generalTextHeight = 0;
+    var generalTextWithFbElements = replaceForbiddenStarsElements(data.general);
+    var recalculateTextHeight = function () {
+      generalTextHeight = calculateTextHeight(ctx, generalTextWithFbElements, 0, marginOrderWidth, interline, fontSize);
+    };
+    var resizeAll = function () {
+      fontSize *= 0.95;
+      interline *= 0.97;
+      recalculateTextHeight();
+    };
+    recalculateTextHeight();
+    while (generalTextHeight > maxFieldsHeight) { resizeAll(); }
+
+    var drawText = function (text, yPosition) {
+      ctx.font = fontSize + 'px ForbiddenStars';
+      var words = text.split(' ');
+      var line = '';
+      var lineHeight = parseInt(ctx.font.match(/\d+/), 10);
+      yPosition += lineHeight;
+      for (var n = 0; n < words.length; n++) {
+        if (words[n] === '*newline*') {
+          ctx.fillText(line, maxWidth * 0.5, yPosition);
+          yPosition += lineHeight + interline;
+          line = '';
+        } else if (words[n] === '*newpara*') {
+          yPosition += 2 * lineHeight;
+          line = '';
+        } else {
+          var testLine = line + words[n] + ' ';
+          var metrics = ctx.measureText(testLine);
+          if (metrics.width > maxWidth - 2 * marginOrderWidth && n > 0) {
+            ctx.fillText(line, maxWidth * 0.5, yPosition);
+            yPosition += lineHeight + interline;
+            line = words[n] + ' ';
+          } else {
+            line = testLine;
+          }
+        }
+      }
+      ctx.fillText(line, maxWidth * 0.5, yPosition);
+    };
+
+    ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
+    ctx.font = titleFontSize + 'px Headline';
+    ctx.textAlign = 'center';
+    ctx.fillText(data.title, maxWidth * 0.5, maxHeight * 0.2325);
+
+    drawText(generalTextWithFbElements, textPosition);
+  }
+
+  async function drawEventCard(data, ctx) {
+    var maxFieldsHeight = maxHeight * 0.278;
+    var textPosition = maxHeight * 0.685;
+
+    var interline = maxHeight * 0.0077;
+    var fontSize = maxHeight * 0.03;
+
+    var picture = await loadImage(data.picture);
+
+    var generalTextHeight = 0;
+    var generalTextWithFbElements = replaceForbiddenStarsElements(data.general);
+    var recalculateTextHeight = function () {
+      generalTextHeight = calculateTextHeight(ctx, generalTextWithFbElements, 20, 0, interline, fontSize);
+    };
+    var resizeAll = function () {
+      fontSize *= 0.95;
+      interline *= 0.97;
+      recalculateTextHeight();
+    };
+    recalculateTextHeight();
+    while (generalTextHeight > maxFieldsHeight) { resizeAll(); }
+
+    var drawText = function (ctx_, text, yPosition) {
+      ctx_.font = fontSize + 'px ForbiddenStars';
+      var words = text.split(' ');
+      var line = '';
+      var lineHeight = parseInt(ctx_.font.match(/\d+/), 10);
+      yPosition += lineHeight;
+      for (var n = 0; n < words.length; n++) {
+        if (words[n] === '*newline*') {
+          ctx_.fillText(line, marginWidth, yPosition);
+          yPosition += lineHeight + interline;
+          line = '';
+        } else if (words[n] === '*newpara*') {
+          ctx_.fillText(line, marginWidth, yPosition);
+          yPosition += 2 * lineHeight;
+          line = '';
+        } else {
+          var testLine = line + words[n] + ' ';
+          var metrics = ctx_.measureText(testLine);
+          if (metrics.width > maxWidth - 2 * marginWidth && n > 0) {
+            ctx_.fillText(line, marginWidth, yPosition);
+            yPosition += lineHeight + interline;
+            line = words[n] + ' ';
+          } else {
+            line = testLine;
+          }
+        }
+      }
+      ctx_.fillText(line, marginWidth, yPosition);
+    };
+
+    ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
+    ctx.font = (titleFontSize * 0.8) + 'px EventFont';
+    ctx.textAlign = 'center';
+    ctx.fillText(data.type, maxWidth * 0.5, maxHeight * 0.573);
+    ctx.font = titleFontSize + 'px Headline';
+    ctx.textAlign = 'left';
+    ctx.fillText(data.title, maxWidth * 0.05, maxHeight * 0.0735);
+    drawText(ctx, generalTextWithFbElements, textPosition);
+  }
+
+  var DRAW = { combat: drawCombatCard, orders: drawOrderCard, events: drawEventCard };
+
+  // Ensure the custom fonts are loaded before we measure/draw text.
+  var _fontsReady;
+  function fontsReady() {
+    if (_fontsReady) return _fontsReady;
+    if (!document.fonts) { _fontsReady = Promise.resolve(); return _fontsReady; }
+    _fontsReady = Promise.all([
+      document.fonts.load('1em ForbiddenStars'),
+      document.fonts.load('1em Headline'),
+      document.fonts.load('1em EventFont'),
+    ]).catch(function () {});
+    return _fontsReady;
+  }
+
+  var _composed = {}; // src -> Promise<dataURL>
+
+  function compose(card) {
+    if (_composed[card.src]) return _composed[card.src];
+    var fn = DRAW[card.kind];
+    if (!fn || !card.text) { _composed[card.src] = Promise.resolve(card.src); return _composed[card.src]; }
+
+    _composed[card.src] = fontsReady().then(function () {
+      var canvas = document.createElement('canvas');
+      canvas.width = maxWidth;
+      canvas.height = maxHeight;
+      var ctx = canvas.getContext('2d');
+      var data = {
+        picture: card.src, hasText: true,
+        title: card.text.title || '',
+        general: card.text.general || '',
+        background: card.text.background || '',
+        foreground: card.text.foreground || '',
+        icons: card.text.icons || '',
+        type: card.text.type || '',
+      };
+      return fn(data, ctx).then(function () { return canvas.toDataURL('image/jpeg', 0.92); });
+    }).catch(function (e) {
+      console.error('compose failed for ' + card.src, e);
+      return card.src; // fall back to the bare template
+    });
+    return _composed[card.src];
+  }
+
+  window.FSCardRender = { compose: compose, fontsReady: fontsReady };
+})();

--- a/page/script/script.js
+++ b/page/script/script.js
@@ -1,1019 +1,537 @@
-async function preloadCanvasFonts() {
-    if (!document.fonts) {
-        return;
+/* Forbidden Stars — Card Codex
+ * Vanilla, data-driven card browser. No framework / no build step.
+ *
+ * Data model (all under page/factions/):
+ *   general.json                       — expansions, categories, default filenames
+ *   <expansion>/faction.json           — factions in that expansion
+ *   <expansion>/<faction>/text.json    — optional per-faction `filenames` override
+ *   <expansion>/<faction>/<folder>/<file>  — the card artwork
+ *
+ * Missing artwork (e.g. an expansion without maps) is handled gracefully: a card
+ * whose image 404s removes itself from the grid.
+ */
+(function () {
+  'use strict';
+
+  var ACCENT = 'amber'; // amber | steel | crimson  (drives --fs-accent CSS vars)
+  var DENSITY = 5;      // grid columns for standard card categories (desktop)
+
+  // Standard-card grid columns adapt to viewport width so cards stay readable
+  // (the lightbox handles zoom). Map (1) and Faction Card (1) layouts unaffected.
+  function density() {
+    var w = window.innerWidth || 1200;
+    if (w <= 480) return 2;
+    if (w <= 720) return 3;
+    if (w <= 1024) return 4;
+    if (w <= 1440) return DENSITY;
+    return DENSITY + 1;
+  }
+
+  // category ref -> on-disk folder (only `map` differs)
+  var FOLDER = {
+    combat: 'combat', orders: 'orders', events: 'events',
+    backs: 'backs', faction_card: 'faction_card', map: 'maps',
+  };
+  // nicer category labels than the raw general.json names, by ref
+  var CAT_LABEL = {
+    combat: 'Combat', orders: 'Orders', events: 'Events',
+    backs: 'Card Backs', faction_card: 'Faction Card', map: 'Maps', material: 'Unit Count',
+  };
+  var TIER_LABELS = ['Standard', 'Tier I', 'Tier II', 'Tier III', 'Tier IV', 'Tier V'];
+  var BACK_LABELS = { combat: 'Combat Deck Back', order: 'Order Deck Back', event: 'Event Deck Back' };
+  // a palette so every faction (across all expansions) gets a distinct dot
+  var DOTS = [
+    'oklch(0.64 0.12 245)', 'oklch(0.57 0.19 25)', 'oklch(0.66 0.15 142)', 'oklch(0.80 0.13 90)',
+    'oklch(0.62 0.16 300)', 'oklch(0.70 0.13 195)', 'oklch(0.60 0.17 350)', 'oklch(0.72 0.14 60)',
+  ];
+
+  var ACC = {
+    amber:   { a: 'oklch(0.80 0.12 80)',  fg: '#1c1810' },
+    steel:   { a: 'oklch(0.72 0.10 232)', fg: '#0b1019' },
+    crimson: { a: 'oklch(0.62 0.185 25)', fg: '#1c0d0c' },
+  };
+
+  /* ---------------- data store ---------------- */
+
+  var DATA = {
+    general: null,          // raw general.json
+    expansions: [],         // [{key, name}]
+    categories: [],         // [{key, name}]
+    defaults: null,         // general.filenames
+    factions: {},           // exp -> [{key, name, dot}]
+    manifest: {},           // "exp/fac" -> {combat:[[..]], orders:[..], ...}  (filenames)
+    text: {},               // "exp/fac" -> {combat:[[{title,general,unit,icons}]], orders:[..], events:[..]} or null
+    loading: {},            // in-flight guards
+  };
+
+  var state = { expansion: null, faction: null, category: 'combat', lb: null, lbFull: false };
+  var flat = []; // flat list of currently-visible cards, for the lightbox
+
+  function setState(patch) {
+    for (var k in patch) { if (patch.hasOwnProperty(k)) state[k] = patch[k]; }
+    render();
+  }
+
+  function fetchJSON(url) {
+    return fetch(url, { cache: 'no-store' }).then(function (r) {
+      if (!r.ok) throw new Error('HTTP ' + r.status + ' for ' + url);
+      return r.json();
+    });
+  }
+
+  // load factions for an expansion (once)
+  function ensureFactions(exp) {
+    if (DATA.factions[exp] || DATA.loading['fac:' + exp]) return;
+    DATA.loading['fac:' + exp] = true;
+    fetchJSON('factions/' + exp + '/faction.json').then(function (fj) {
+      var list = (fj.folder || []).map(function (key, i) {
+        return { key: key, name: (fj.name && fj.name[i]) || key, dot: DOTS[i % DOTS.length] };
+      });
+      DATA.factions[exp] = list;
+      // prefetch manifests so sidebar counts populate
+      list.forEach(function (f) { ensureManifest(exp, f.key); });
+      // if no faction selected for the now-active expansion, pick the first
+      if (state.expansion === exp && !state.faction && list[0]) state.faction = list[0].key;
+      render();
+    }).catch(function (e) {
+      DATA.factions[exp] = [];
+      console.error(e);
+      render();
+    });
+  }
+
+  // load a faction's filename manifest (text.json override, else defaults)
+  function ensureManifest(exp, fac) {
+    var id = exp + '/' + fac;
+    if (DATA.manifest[id] || DATA.loading['man:' + id]) return;
+    DATA.loading['man:' + id] = true;
+    fetchJSON('factions/' + exp + '/' + fac + '/text.json').then(function (t) {
+      DATA.manifest[id] = mergeFilenames(t && t.filenames);
+      DATA.text[id] = {
+        combat: (t && t.combatText) || null,
+        orders: (t && t.ordersText) || null,
+        events: (t && t.eventsText) || null,
+        materials: (t && t.materialsText) || null,
+      };
+      render();
+    }).catch(function () {
+      // no text.json -> use the global defaults, no overlay text
+      DATA.manifest[id] = mergeFilenames(null);
+      DATA.text[id] = { combat: null, orders: null, events: null, materials: null };
+      render();
+    });
+  }
+
+  function mergeFilenames(over) {
+    var d = DATA.defaults || {};
+    over = over || {};
+    return {
+      combat: over.combat || d.combat || [],
+      orders: over.orders || d.orders || [],
+      events: over.events || d.events || [],
+      backs: over.backs || d.backs || [],
+      faction_card: over.faction_card || d.faction_card || [],
+      map: over.map || d.map || [],
+    };
+  }
+
+  function manifestCount(man) {
+    if (!man) return null;
+    var n = 0;
+    (man.combat || []).forEach(function (tier) { n += tier.length; });
+    ['orders', 'events', 'backs', 'faction_card', 'map'].forEach(function (k) { n += (man[k] || []).length; });
+    return n;
+  }
+
+  /* ---------------- lookups ---------------- */
+
+  function facList() { return DATA.factions[state.expansion] || []; }
+  function facName(k) { var f = findKey(facList(), k); return f ? f.name : ''; }
+  function catName(k) { return CAT_LABEL[k] || (function () { var c = findKey(DATA.categories, k); return c ? c.name : ''; })(); }
+  function expName(k) { var e = findKey(DATA.expansions, k); return e ? e.name : ''; }
+  function findKey(list, key) {
+    for (var i = 0; i < list.length; i++) { if (list[i].key === key) return list[i]; }
+    return null;
+  }
+
+  /* ---------------- element builder ---------------- */
+
+  function el(tag, props, children) {
+    var node = document.createElement(tag);
+    props = props || {};
+    for (var key in props) {
+      if (!props.hasOwnProperty(key)) continue;
+      var val = props[key];
+      if (val == null) continue;
+      if (key === 'class') node.className = val;
+      else if (key === 'html') node.innerHTML = val;
+      else if (key === 'text') node.textContent = val;
+      else if (key.indexOf('on') === 0 && typeof val === 'function') {
+        node.addEventListener(key.slice(2).toLowerCase(), val);
+      } else {
+        node.setAttribute(key, val);
+      }
+    }
+    if (children) {
+      if (!Array.isArray(children)) children = [children];
+      for (var i = 0; i < children.length; i++) {
+        var c = children[i];
+        if (c == null || c === false) continue;
+        node.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+      }
+    }
+    return node;
+  }
+
+  // For template cards (e.g. Symphony of War) draw the card text onto the art
+  // and swap in the composited image once ready. Bare-art cards are left as-is.
+  function applyComposite(imgEl, card) {
+    if (!card.text || !card.kind || !window.FSCardRender) return;
+    window.FSCardRender.compose(card).then(function (url) {
+      if (url && url !== card.src) imgEl.src = url;
+    });
+  }
+
+  function lbImg(card) {
+    var img = el('img', { src: card.src, alt: card.label });
+    applyComposite(img, card);
+    return img;
+  }
+
+  // "Unit Count" — a faction's component tally, rendered as a table card.
+  function renderMaterial(materials) {
+    var body;
+    if (materials && materials.length) {
+      body = el('div', { class: 'fs-material-body' }, materials.map(function (item) {
+        if (typeof item === 'string') return el('div', { class: 'fs-material-line', text: item });
+        return el('div', { class: 'fs-material-line' }, [
+          el('span', { class: 'fs-material-label', text: (item && item.label) || '' }),
+          el('span', { class: 'fs-material-value', text: (item && item.value != null) ? String(item.value) : '' }),
+        ]);
+      }));
+    } else {
+      body = el('div', { class: 'fs-material-body' }, [
+        el('p', { class: 'fs-note', text: 'Unit counts not available for this faction.' }),
+      ]);
+    }
+    return el('div', { class: 'fs-material-card' }, [
+      el('div', { class: 'fs-material-heading', text: 'Material' }),
+      body,
+    ]);
+  }
+
+  function maybeEmptyNote(scrollarea) {
+    if (!scrollarea || scrollarea.querySelector('.fs-note')) return;
+    var cards = scrollarea.querySelectorAll('.fs-card');
+    for (var i = 0; i < cards.length; i++) {
+      if (cards[i].style.display !== 'none') return; // still something visible
+    }
+    if (cards.length) scrollarea.appendChild(el('div', { class: 'fs-note', text: 'No artwork available for this set.' }));
+  }
+
+  /* ---------------- card model ---------------- */
+
+  function build() {
+    var fac = state.faction, cat = state.category;
+    var id = state.expansion + '/' + fac;
+    var man = DATA.manifest[id];
+    var txt = DATA.text[id];
+    var groups = [];
+    flat = [];
+    if (!man || !fac) return { groups: groups, ready: false };
+
+    // "Unit Count" is a data table, not an image grid
+    if (cat === 'material') {
+      return { groups: groups, ready: true, material: (txt && txt.materials) || null };
     }
 
-    const families = ['ForbiddenStars', 'Headline', 'EventFont'];
-    const fontLoads = families.map(family => document.fonts.load(`1em ${family}`));
-
-    try {
-        await Promise.all([...fontLoads, document.fonts.ready]);
-    } catch (error) {
-        console.warn('Some canvas fonts did not finish loading before the first draw.', error);
+    var base = 'factions/' + state.expansion + '/' + fac + '/' + FOLDER[cat] + '/';
+    function push(file, label, kind, text) {
+      var idx = flat.length;
+      var c = { src: base + file, label: label, index: idx, kind: kind || null, text: text || null };
+      flat.push(c);
+      return c;
     }
-}
 
-document.addEventListener('DOMContentLoaded', async function () {
-	await preloadCanvasFonts();
-	const expansionTabsContainer = document.getElementById('expansion-tabs');
-	const factionTabsContainer = document.getElementById('faction-tabs');
-	const cardsContentsContainer = document.getElementById('cards-tabs');
-	const cardsContainer = document.getElementById('cards-container');
-	const faqContainer = document.getElementById('faq-container');
-	const faqContent = document.getElementById('faq-content');
-	const faqSearchInput = document.getElementById('faq-search-input');
-	const faqSearchMeta = document.getElementById('faq-search-meta');
-	const FAQ_JSON_PATH = './data/FAQ.json';
-
-	let faqOriginalData = [];
-	let faqLoaded = false;
-	let faqLoadingPromise = null;
-
-	const normalizeFaqValue = (value) => String(value ?? '').toLowerCase();
-	const faqMatches = (value, query) => normalizeFaqValue(value).includes(query);
-	const faqEscapeHtml = (str) => String(str ?? '')
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/\"/g, '&quot;')
-		.replace(/'/g, '&#039;');
-	const faqWithArray = (value) => Array.isArray(value) ? value : [];
-	const getFaqPicture = (node) => node && typeof node === 'object' ? node.picture || '' : '';
-
-	function normalizeFaqMainText(value) {
-		return String(value ?? '')
-			.replace(/\\r\\n/g, '\n')
-			.replace(/\\n/g, '\n');
-	}
-
-	function highlightFaqText(text, query) {
-		const raw = String(text ?? '');
-		if (!query) {
-			return faqEscapeHtml(raw);
-		}
-
-		const escaped = faqEscapeHtml(raw);
-		const safeQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-		const regex = new RegExp(`(${safeQuery})`, 'ig');
-		return escaped.replace(regex, '<mark>$1</mark>');
-	}
-
-	function createFaqLevelRow(textHtml, picture) {
-		const row = document.createElement('div');
-		row.className = `faq-level-row ${picture ? '' : 'no-picture'}`.trim();
-
-		const textWrap = document.createElement('div');
-		textWrap.innerHTML = textHtml;
-		row.appendChild(textWrap);
-
-		if (picture) {
-			const img = document.createElement('img');
-			img.className = 'faq-level-image';
-			img.src = picture;
-			img.alt = '';
-			img.loading = 'lazy';
-			row.appendChild(img);
-		}
-		return row;
-	}
-
-	function renderFaqPhraseBlock(phraseObj, query) {
-		const phraseBlock = document.createElement('section');
-		phraseBlock.className = 'faq-phrase-block faq-level-block';
-
-		const phraseText = phraseObj.Phrase ?? '';
-		const mainText = normalizeFaqMainText(phraseObj.Main ?? '');
-		const picture = getFaqPicture(phraseObj);
-
-		const textHtml = `
-			<div class="faq-phrase-title"><strong>${highlightFaqText(phraseText, query)}</strong></div>
-			<div class="faq-main-text">${highlightFaqText(mainText, query)}</div>
-		`;
-
-		phraseBlock.appendChild(createFaqLevelRow(textHtml, picture));
-		return phraseBlock;
-	}
-
-	function renderFaqFactionBlock(factionObj, query) {
-		const block = document.createElement('section');
-		block.className = 'faq-faction-block faq-level-block';
-
-		const title = factionObj.Faction ?? '';
-		const picture = getFaqPicture(factionObj);
-		const headerHtml = `
-			<h3>${highlightFaqText(title, query)}</h3>
-			<div class="faq-separator"></div>
-		`;
-
-		block.appendChild(createFaqLevelRow(headerHtml, picture));
-
-		faqWithArray(factionObj.items).forEach((phraseObj) => {
-			block.appendChild(renderFaqPhraseBlock(phraseObj, query));
-		});
-
-		return block;
-	}
-
-	function renderFaqSubCategoryBlock(subObj, query) {
-		const block = document.createElement('section');
-		block.className = 'faq-subcategory-block faq-level-block';
-
-		const title = subObj.SubCategory ?? '';
-		const picture = getFaqPicture(subObj);
-		const headerHtml = `
-			<h2>${highlightFaqText(title, query)}</h2>
-			<div class="faq-separator"></div>
-		`;
-
-		block.appendChild(createFaqLevelRow(headerHtml, picture));
-
-		faqWithArray(subObj.items).forEach((factionObj) => {
-			block.appendChild(renderFaqFactionBlock(factionObj, query));
-		});
-
-		return block;
-	}
-
-	function renderFaqCategoryBlock(categoryObj, query) {
-		const block = document.createElement('section');
-		block.className = 'faq-category-block faq-level-block';
-
-		const title = categoryObj.Category ?? '';
-		const picture = getFaqPicture(categoryObj);
-		const headerHtml = `
-			<h1>${highlightFaqText(title, query)}</h1>
-			<div class="faq-separator"></div>
-		`;
-
-		block.appendChild(createFaqLevelRow(headerHtml, picture));
-
-		faqWithArray(categoryObj.items).forEach((subObj) => {
-			block.appendChild(renderFaqSubCategoryBlock(subObj, query));
-		});
-
-		return block;
-	}
-
-	function renderFaq(data, query = '') {
-		if (!faqContent) {
-			return;
-		}
-
-		faqContent.innerHTML = '';
-
-		if (!data.length) {
-			const empty = document.createElement('div');
-			empty.className = 'faq-empty-state';
-			empty.textContent = query ? 'No results found.' : 'No FAQ entries available.';
-			faqContent.appendChild(empty);
-			return;
-		}
-
-		data.forEach((categoryObj) => {
-			faqContent.appendChild(renderFaqCategoryBlock(categoryObj, query));
-		});
-	}
-
-	function filterFaqData(data, rawQuery) {
-		const query = normalizeFaqValue(rawQuery).trim();
-		if (!query) {
-			return data;
-		}
-
-		return faqWithArray(data).flatMap((categoryObj) => {
-			const filteredSubCategories = faqWithArray(categoryObj.items).flatMap((subObj) => {
-				if (faqMatches(subObj.SubCategory, query)) {
-					return [subObj];
-				}
-
-				const filteredFactions = faqWithArray(subObj.items).flatMap((factionObj) => {
-					if (faqMatches(factionObj.Faction, query)) {
-						return [factionObj];
-					}
-
-					const filteredPhrases = faqWithArray(factionObj.items).filter((phraseObj) => {
-						return faqMatches(phraseObj.Phrase, query) || faqMatches(phraseObj.Main, query);
-					});
-
-					if (filteredPhrases.length) {
-						return [{
-							...factionObj,
-							items: filteredPhrases
-						}];
-					}
-
-					return [];
-				});
-
-				if (filteredFactions.length) {
-					return [{
-						...subObj,
-						items: filteredFactions
-					}];
-				}
-
-				return [];
-			});
-
-			if (filteredSubCategories.length) {
-				return [{
-					...categoryObj,
-					items: filteredSubCategories
-				}];
-			}
-
-			return [];
-		});
-	}
-
-	function updateFaqSearchResults(rawQuery) {
-		const query = rawQuery.trim();
-		const filtered = filterFaqData(faqOriginalData, rawQuery);
-		renderFaq(filtered, query);
-
-		if (faqSearchMeta) {
-			faqSearchMeta.textContent = query
-				? `Search: "${query}"`
-				: 'Showing full FAQ';
-		}
-	}
-
-	async function loadFaq() {
-		if (faqLoaded) {
-			return faqOriginalData;
-		}
-
-		if (faqLoadingPromise) {
-			return faqLoadingPromise;
-		}
-
-		faqLoadingPromise = fetch(FAQ_JSON_PATH, { cache: 'no-store' })
-			.then((response) => {
-				if (!response.ok) {
-					throw new Error(`Failed to load FAQ JSON: ${response.status}`);
-				}
-
-				return response.json();
-			})
-			.then((data) => {
-				faqOriginalData = Array.isArray(data) ? data : [];
-				faqLoaded = true;
-				updateFaqSearchResults(faqSearchInput?.value ?? '');
-				return faqOriginalData;
-			})
-			.catch((error) => {
-				console.error(error);
-				faqLoaded = false;
-
-				if (faqContent) {
-					faqContent.innerHTML = '<div class="faq-empty-state">Failed to load FAQ data.</div>';
-				}
-
-				throw error;
-			})
-			.finally(() => {
-				faqLoadingPromise = null;
-			});
-
-		return faqLoadingPromise;
-	}
-
-	const showCardsView = () => {
-		if (factionTabsContainer) factionTabsContainer.style.display = '';
-		if (cardsContentsContainer) cardsContentsContainer.style.display = '';
-		if (cardsContainer) cardsContainer.style.display = '';
-		if (faqContainer) faqContainer.classList.remove('active');
-	};
-
-	const showFaqView = () => {
-		if (factionTabsContainer) factionTabsContainer.style.display = 'none';
-		if (cardsContentsContainer) cardsContentsContainer.style.display = 'none';
-		if (cardsContainer) cardsContainer.style.display = 'none';
-		if (faqContainer) faqContainer.classList.add('active');
-		loadFaq().catch(() => {});
-	};
-
-	if (faqSearchInput) {
-		faqSearchInput.addEventListener('input', (event) => {
-			updateFaqSearchResults(event.target.value);
-		});
-	}
-
-	// Size of cards - rest is calculated just based on this.
-	const maxWidth = 450;
-	const maxHeight = 650;
-
-	// Size of boxes for combat cards.
-	const textBackgroundSize = 759;
-	const textBottomBarHeight = 18;
-	const textBottomBarWidth = 454;
-
-	const titleFontSize = maxHeight * 0.05;
-	const marginWidth = maxWidth * 0.0578;
-	const maxTextWidth = maxWidth - 2 * marginWidth;
-
-	// Icons positioning predefinitions.
-	const iconSize = maxWidth * 0.097;
-	const iconSpacing = maxWidth * 0.011;
-	const iconX = maxWidth * 0.0632;
-	const startY = maxHeight * 0.242;
-
-	const iconMap = {
-		'B': 'pictures/bolter.png',
-		'S': 'pictures/shield.png',
-		'M': 'pictures/moral.png'
-	};
-
-	// MENU SECTION BUILDER
-	fetch('factions/general.json')
-		.then(response => response.json())
-		.then(generalData => {
-			var firstRun = true;
-			expansionTabsContainer.innerHTML = '';
-
-			const expansionFolderList = generalData.expansion.folder;
-			const expansionNameList = generalData.expansion.name;
-
-			expansionFolderList.forEach((expansionFolder, expansionFolderIndex) => {
-				const expansionTabHeader = document.createElement('div');
-				expansionTabHeader.textContent = expansionNameList[expansionFolderIndex];
-				expansionTabHeader.classList.add('expansion-header');
-				expansionTabHeader.dataset.expansion = expansionFolder;
-				if (expansionFolderIndex === 0) expansionTabHeader.classList.add('active');
-				expansionTabsContainer.appendChild(expansionTabHeader);
-			});
-
-			const faqTabHeader = document.createElement('div');
-			faqTabHeader.textContent = 'FAQ';
-			faqTabHeader.classList.add('expansion-header');
-			faqTabHeader.dataset.expansion = 'faq';
-			faqTabHeader.dataset.special = 'faq';
-			expansionTabsContainer.appendChild(faqTabHeader);
-
-			expansionTabsContainer.addEventListener('click', function (e) {
-				if (e.target.classList.contains('expansion-header')) {
-					const isFaqTab = e.target.dataset.special === 'faq';
-					const buttonExp = e.target.dataset.expansion;
-					document.querySelectorAll('.expansion-header').forEach(h => h.classList.remove('active'));
-					e.target.classList.add('active');
-					if (isFaqTab) {
-						showFaqView();
-					} else {
-						showCardsView();
-						loadFactions(buttonExp);
-					}
-				}
-			});
-
-			if (firstRun === true) {
-				showCardsView();
-				loadFactions(expansionFolderList[0]);
-			}
-
-			function loadFactions(expansionFolder_) {
-				factionTabsContainer.innerHTML = '';
-				fetch('factions/' + expansionFolder_ + '/faction.json')
-					.then(response => response.json())
-					.then(expansionData => {
-
-						const factionFolderList = expansionData.folder;
-						const factionNameList = expansionData.name;
-
-						factionFolderList.forEach((factionFolder, factionFolderIndex) => {
-							const factionTabHeader = document.createElement('div');
-							factionTabHeader.textContent = factionNameList[factionFolderIndex];
-							factionTabHeader.classList.add('faction-header');
-							factionTabHeader.dataset.faction = factionFolder;
-							factionTabHeader.dataset.expansion = expansionFolder_;
-							if (factionFolderIndex === 0) factionTabHeader.classList.add('active');
-							factionTabsContainer.appendChild(factionTabHeader);
-						});
-
-						factionTabsContainer.addEventListener('click', function (e) {
-							if (e.target.classList.contains('faction-header')) {
-								const buttonExp = e.target.dataset.expansion;
-								const buttonFac = e.target.dataset.faction;
-								document.querySelectorAll('.faction-header').forEach(h => h.classList.remove('active'));
-								e.target.classList.add('active');
-								loadCardsMenu(buttonExp, buttonFac);
-							}
-						});
-
-						if (firstRun) {
-							loadCardsMenu(expansionFolder_, factionFolderList[0]);
-						}
-
-						function loadCardsMenu(expansionFolder__, factionFolder_) {
-
-							const cardsDefaultName = generalData.cardsDefault.name;
-							const cardsDefaultReference = generalData.cardsDefault.reference;
-							cardsContentsContainer.innerHTML = '';
-							cardsDefaultReference.forEach((reference, referenceIndex) => {
-								const cardTabHeader = document.createElement('div');
-								cardTabHeader.textContent = cardsDefaultName[referenceIndex];
-								cardTabHeader.classList.add('card-header');
-								cardTabHeader.dataset.faction = factionFolder_;
-								cardTabHeader.dataset.expansion = expansionFolder__;
-								cardTabHeader.dataset.cardType = reference;
-								if (referenceIndex === 0) cardTabHeader.classList.add('active');
-								cardsContentsContainer.appendChild(cardTabHeader);
-							});
-
-							cardsContentsContainer.addEventListener('click', function (e) {
-								if (e.target.classList.contains('card-header')) {
-									const buttonExp = e.target.dataset.expansion;
-									const buttonFac = e.target.dataset.faction;
-									const buttonCard = e.target.dataset.cardType;
-									document.querySelectorAll('.card-header').forEach(h => h.classList.remove('active'));
-									e.target.classList.add('active');
-									loadCards(buttonExp, buttonFac, buttonCard);
-								}
-							});
-
-							if (firstRun) {
-								loadCards(expansionFolder__, factionFolder_, cardsDefaultReference[0]);
-							}
-
-							function loadCards(expansionFolder___, factionFolder__, cardTypeReference) {
-								cardsContainer.innerHTML = '';
-								const subTabContents = document.createElement('div');
-								subTabContents.classList.add('card-contents');
-								subTabContents.id = `cards-${expansionFolder___}-${factionFolder__}-${cardTypeReference}`;
-								cardsContainer.appendChild(subTabContents);
-
-								fetch(`factions/${expansionFolder___}/${factionFolder__}/text.json`)
-									.then(response => response.ok ? response.json() : "")
-									.then(textData => {
-										console.log(textData);
-										const cardsFilenameCombatList = textData?.filenames?.combat ?? generalData.filenames.combat;
-										const cardsFilenameOrderList = textData?.filenames?.orders ?? generalData.filenames.orders;
-										const cardsFilenameEventList = textData?.filenames?.events ?? generalData.filenames.events;
-										const cardsFilenameFactioncardList = textData?.filenames?.faction_card ?? generalData.filenames.faction_card;
-										const cardsFilenameBacksList = textData?.filenames?.backs ?? generalData.filenames.backs;
-										const cardsFilenameMapList = textData?.filenames?.map ?? generalData.filenames.map;
-										const cardsOrdersText = textData?.ordersText ?? false;
-										const cardsEventsText = textData?.eventsText ?? false;
-										const cardsCombatText = textData?.combatText ?? false;
-									const cardsMaterialsText = textData?.materialsText ?? false;
-									if (cardTypeReference === "combat") {
-										createCombatContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameCombatList, cardsCombatText);
-									} else if (cardTypeReference === "orders") {
-										createOrdersContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameOrderList, cardsOrdersText);
-									} else if (cardTypeReference === "events") {
-										createEventContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameEventList, cardsEventsText);
-									} else if (cardTypeReference === "material") {
-										createMaterialContent(subTabContents, expansionFolder___, factionFolder__, cardsMaterialsText);
-										} else if (cardTypeReference === "faction_card") {
-											createFactioncardContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameFactioncardList);
-										} else if (cardTypeReference === "backs") {
-											backCardContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameBacksList);
-										} else if (cardTypeReference === "map") {
-											mapCardContent(subTabContents, expansionFolder___, factionFolder__, cardsFilenameMapList);
-										}
-									})
-									.catch(error => console.error('Error loading text.json:', error));
-							};
-						};
-					});
-			};
-		})
-		.catch(error => console.error('Error loading file_names.json:', error));
-	firstRun = false;
-
-	function createPlaceholderWithSpinner() {
-			const placeholder = document.createElement('div');
-			placeholder.classList.add('card-placeholder');
-			const spinner = document.createElement('div');
-			spinner.classList.add('card-spinner');
-			placeholder.appendChild(spinner);
-			return placeholder;
-	}
-
-	//   CREATING CONTENT FOR CANVAS
-	function createCombatContent(container, expansionFolder, factionfolder, files, textData) {
-		const sections = {
-			's-section': files[0],
-			't1-section': files[1],
-			't2-section': files[2],
-			't3-section': files[3]
-		};
-
-		const combatText = textData
-			? {
-				's-section': textData[0],
-				't1-section': textData[1],
-				't2-section': textData[2],
-				't3-section': textData[3]
-			} : false;
-		
-		Object.keys(sections).forEach(section => {
-			const sectionContainer = document.createElement('div');
-			sectionContainer.classList.add('grid', 'combat', section);
-			sections[section].forEach((file, idx) => {
-				// Create placeholder with spinner
-				const placeholder = createPlaceholderWithSpinner();
-				sectionContainer.appendChild(placeholder);
-
-				// Prepare card data
-				const jsonData = {};
-				jsonData["picture"] = `factions/${expansionFolder}/${factionfolder}/combat/${file}`;
-				if (combatText) {
-					jsonData["hasText"] = true;
-					jsonData["title"] = combatText[section][idx].title || "";
-					jsonData["background"] = combatText[section][idx].general || "";
-					jsonData["foreground"] = combatText[section][idx].unit || "";
-					jsonData["icons"] = combatText[section][idx].icons || "";
-				} else {
-					jsonData["hasText"] = false;
-				}
-
-				const canvas = document.createElement('canvas');
-				canvas.width = maxWidth;
-				canvas.height = maxHeight;
-				const context = canvas.getContext('2d');
-
-				drawCombatCard(jsonData, context).then(() => {
-					placeholder.replaceWith(canvas);
-				}).catch(err => {
-					console.error('Error drawing combat card:', err);
-					placeholder.innerHTML = 'Error loading image';
-				});
-			});
-			container.appendChild(sectionContainer);
-		});
-	}
-
-
-	function createOrdersContent(container, expansionFolder, factionfolder, files, textData) {
-		const categoryContainer = document.createElement('div');
-		categoryContainer.classList.add('grid', 'orders');
-
-		files.forEach((file, idx) => {
-			const placeholder = createPlaceholderWithSpinner();
-			categoryContainer.appendChild(placeholder);
-			const jsonData = {};
-			jsonData["picture"] = `factions/${expansionFolder}/${factionfolder}/orders/${file}`;
-			if (textData) {
-				jsonData["hasText"] = true;
-				jsonData["title"] = `${textData[idx].title}`;
-				jsonData["general"] = `${textData[idx].general}`;
-			} else {
-				jsonData["hasText"] = false;
-			}
-
-			const canvas = document.createElement('canvas');
-			canvas.width = maxWidth;
-			canvas.height = maxHeight;
-			const context = canvas.getContext('2d');
-
-			// Draw card and replace placeholder when done
-			drawOrderCard(jsonData, context).then(() => {
-				placeholder.replaceWith(canvas);
-			}).catch(err => {
-				console.error('Error drawing order card:', err);
-				placeholder.innerHTML = 'Error loading image';
-			});
-		});
-
-		container.appendChild(categoryContainer);
-	}
-
-	function createEventContent(container, expansionFolder, factionfolder, files, textData) {
-		const categoryContainer = document.createElement('div');
-		categoryContainer.classList.add('grid', 'events');
-
-		files.forEach((file, idx) => {
-			const placeholder = createPlaceholderWithSpinner();
-			categoryContainer.appendChild(placeholder);
-			const jsonData = {};
-			jsonData["picture"] = `factions/${expansionFolder}/${factionfolder}/events/${file}`;
-
-			if (textData) {
-				jsonData["hasText"] = true;
-				jsonData["title"] = `${textData[idx].title}`;
-				jsonData["general"] = `${textData[idx].general}`;
-				jsonData["type"] = `${textData[idx].type}`;
-			} else {
-				jsonData["hasText"] = false;
-			}
-
-			const canvas = document.createElement('canvas');
-			canvas.width = maxWidth;
-			canvas.height = maxHeight;
-			const context = canvas.getContext('2d');
-
-			// Draw card and replace placeholder when done
-			drawEventCard(jsonData, context).then(() => {
-				placeholder.replaceWith(canvas);
-			}).catch(err => {
-				console.error('Error drawing event card:', err);
-				placeholder.innerHTML = 'Error loading image';
-			});
-		});
-		container.appendChild(categoryContainer);
-	}
-
-	function createMaterialContent(container, expansionFolder, factionfolder, materialsText) {
-		const categoryContainer = document.createElement('div');
-		categoryContainer.classList.add('grid', 'materials');
-
-		const materialCard = document.createElement('div');
-		materialCard.classList.add('material-card');
-
-		const heading = document.createElement('div');
-		heading.classList.add('material-heading');
-		heading.textContent = 'Material';
-		materialCard.appendChild(heading);
-
-		const body = document.createElement('div');
-		body.classList.add('material-body');
-
-		if (materialsText && Array.isArray(materialsText) && materialsText.length) {
-			materialsText.forEach(item => {
-				const line = document.createElement('div');
-				line.classList.add('material-line');
-				if (typeof item === 'string') {
-					line.textContent = item;
-				} else if (item && typeof item === 'object') {
-					const label = document.createElement('span');
-					label.classList.add('material-label');
-					label.textContent = item.label || '';
-					const value = document.createElement('span');
-					value.classList.add('material-value');
-					value.textContent = item.value || '';
-					line.appendChild(label);
-					if (item.label && item.value) {
-						line.appendChild(document.createTextNode(': '));
-					}
-					line.appendChild(value);
-				} else {
-					line.textContent = String(item);
-				}
-				body.appendChild(line);
-			});
-		} else {
-			const empty = document.createElement('p');
-			empty.classList.add('material-empty');
-			empty.textContent = 'Material information not available for this faction.';
-			body.appendChild(empty);
-		}
-
-		materialCard.appendChild(body);
-		categoryContainer.appendChild(materialCard);
-		container.appendChild(categoryContainer);
-	}
-
-function imageLoaderUniversal(files, maxWidth, maxHeight, pathToImage, container, categoryContainer) {
-	files.forEach((file, _) => {
-			const placeholder = createPlaceholderWithSpinner();
-			categoryContainer.appendChild(placeholder);
-			const img = document.createElement('img');
-			img.src = pathToImage+file;
-			if (maxWidth) img.width = maxWidth;
-			if (maxHeight) img.height = maxHeight;
-			img.onload = () => {
-				placeholder.replaceWith(img);
-			};
-			img.onerror = () => {
-				placeholder.innerHTML = 'Error loading image';
-			};
-		});
-		container.appendChild(categoryContainer);
-}
-
-	function createFactioncardContent(container, expansionFolder, factionfolder, files) {
-		const categoryContainer = document.createElement('div');
-		categoryContainer.classList.add('grid','factionCardImage');
-		imageLoaderUniversal(files, maxWidth*3, false, `factions/${expansionFolder}/${factionfolder}/faction_card/`, container, categoryContainer);
-	}
-
-	function backCardContent(container, expansionFolder, factionfolder, files) {
-		const categoryContainer = document.createElement('div');
-		categoryContainer.classList.add('grid', 'cardBackImages');
-		imageLoaderUniversal(files, maxWidth, maxHeight, `factions/${expansionFolder}/${factionfolder}/backs/`, container, categoryContainer);
-	}
-
-	function mapCardContent(container, expansionFolder, factionfolder, files) {
-		const categoryContainer = document.createElement('div');
-		categoryContainer.classList.add('grid', 'mapImages');
-		imageLoaderUniversal(files, maxWidth*2, false, `factions/${expansionFolder}/${factionfolder}/maps/`, container, categoryContainer);
-	}
-
-	// CANVAS TOOLS
-	function replaceForbiddenStarsElements(str) {
-		str = str.replace(/\[B\]/g, "}");
-		str = str.replace(/\[S\]/g, "{");
-		str = str.replace(/\[M\]/g, "<");
-		str = str.replace(/\[D\]/g, "|");
-		str = str.replace(/\(B\)/g, "#");
-		str = str.replace(/\(S\)/g, "@");
-		return str
-	}
-
-	function calculateTextHeight(context, text, extraHeight, marginHeight, interline, fontSize) {
-		context.font = `${fontSize}px ForbiddenStars`;
-		const words = text.split(' ');
-		let line = '';
-		let lineHeight = parseInt(context.font.match(/\d+/), 10);
-		let returnHeight = 0;
-		for (let n = 0; n < words.length; n++) {
-			if (words[n] === "*newline*") {
-				returnHeight += lineHeight + interline;
-				line = '';
-			}
-			else if (words[n] === "*newpara*") {
-				returnHeight += 2 * lineHeight;
-				line = '';
-			}
-			else {
-				const testLine = line + words[n] + ' ';
-				const metrics = context.measureText(testLine);
-				if (metrics.width > maxTextWidth && n > 0) {
-					returnHeight += lineHeight + interline;
-					line = words[n] + ' ';
-				} else {
-					line = testLine;
-				}
-			}
-		}
-		returnHeight += lineHeight * 2 + extraHeight + marginHeight * 2;
-		return returnHeight;
-	};
-
-
-	function loadImage(url) {
-		return new Promise((resolve, reject) => {
-			const img = new Image();
-			img.src = url;
-			img.onload = () => resolve(img);
-			img.onerror = () => reject(new Error('Failed to load image'));
-		});
-	};
-
-	// DRAWING CANVAS SECTION
-	async function drawCombatCard(data, ctx) {
-		const bottomImageheight = maxHeight * 0.025;
-		const maxFieldsHeight = maxHeight * 0.4;
-		const extraForegroundTriangle = maxHeight * 0.0455;
-		const extraBackgroundborder = maxHeight * 0.0385;
-
-		let interline = maxHeight * 0.0077;
-		let marginHeight = maxWidth * 0.05;
-		let fontSize = maxHeight * 0.03;
-
-		// Load images from paths
-		const picture = await loadImage(data.picture);
-		const background = await loadImage('pictures/background.png');
-		const foreground = await loadImage('pictures/foreground.png');
-		const bottomImage = await loadImage('pictures/bottom.png');
-
-		// Initial settings for margin and font size
-		let backgroundTextHeight = 0;
-		let foregroundTextHeight = 0;
-
-		// Draw the main picture resized
-		if (!data.hasText) {
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-
-		} else {
-
-			const backgroundWithFbElements = replaceForbiddenStarsElements(data.background)
-			const foregroundWithFbElements = replaceForbiddenStarsElements(data.foreground)
-
-			// Cards text height Declaration
-			const recalculateTextHeight = () => {
-				if (data.background.length > 0) {
-					backgroundTextHeight = calculateTextHeight(ctx, backgroundWithFbElements, extraBackgroundborder, marginHeight, interline, fontSize);
-				}
-				if (data.foreground.length > 0) {
-					foregroundTextHeight = calculateTextHeight(ctx, foregroundWithFbElements, extraForegroundTriangle, marginHeight, interline, fontSize);
-				}
-			};
-			recalculateTextHeight()
-
-			const resizeCardText = () => {
-				marginHeight *= 0.8;
-				fontSize *= 0.99;
-				interline *= 0.95;
-				recalculateTextHeight();
-			};
-
-			if (data.background.length > 0 && data.foreground.length > 0) {
-				while ((backgroundTextHeight + foregroundTextHeight) > maxFieldsHeight) {
-					resizeCardText();
-				};
-			} else {
-				while (Math.max(backgroundTextHeight, foregroundTextHeight) > maxFieldsHeight) {
-					resizeCardText();
-				};
-			};
-
-			const drawText = (text, yPosition, extra) => {
-				ctx.font = `${fontSize}px ForbiddenStars`;
-				const words = text.split(' ');
-				let line = '';
-				let lineHeight = parseInt(ctx.font.match(/\d+/), 10);
-				yPosition += marginHeight + extra + lineHeight;
-				for (let n = 0; n < words.length; n++) {
-					if (words[n] === "*newline*") {
-						ctx.fillText(line, marginWidth, yPosition);
-						yPosition += lineHeight + interline;
-						line = '';
-					}
-					else if (words[n] === "*newpara*") {
-						ctx.fillText(line, marginWidth, yPosition);
-						yPosition += 2 * lineHeight;
-						line = '';
-					}
-					else {
-						const testLine = line + words[n] + ' ';
-						const metrics = ctx.measureText(testLine);
-						if (metrics.width > maxWidth - 2 * marginWidth && n > 0) {
-							ctx.fillText(line, marginWidth, yPosition);
-							yPosition += lineHeight + interline;
-							line = words[n] + ' ';
-						} else {
-							line = testLine;
-						};
-					};
-				};
-				ctx.fillText(line, marginWidth, yPosition);
-			};
-
-			const drawImageCropped = (img, height) => {
-				ctx.drawImage(img, 0, 0, textBackgroundSize, maxHeight - height, 0, height, maxWidth, maxHeight - height);
-			};
-
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-			ctx.font = `${titleFontSize}px Headline`;
-			ctx.fillText(data.title, maxWidth * 0.27, maxHeight * 0.077);
-
-			if (data.background.length > 0) {
-				const backgroundY = maxHeight - (backgroundTextHeight + foregroundTextHeight);
-				drawImageCropped(background, backgroundY);
-				drawText(backgroundWithFbElements, backgroundY, extraBackgroundborder);
-			}
-			if (data.foreground.length > 0) {
-				const foregroundY = maxHeight - (foregroundTextHeight + extraForegroundTriangle * 0.35);
-				drawImageCropped(foreground, foregroundY);
-				drawText(foregroundWithFbElements, foregroundY, extraForegroundTriangle);
-			}
-			if (data.icons && data.icons.length > 0) {
-				let currentY = startY;
-				for (let letterPosition = 0; letterPosition < data.icons.length; letterPosition++) {
-					const iconChar = data.icons[letterPosition].toUpperCase();
-					if (iconMap[iconChar]) {
-						const iconImg = await loadImage(iconMap[iconChar]);
-						ctx.drawImage(iconImg, iconX, currentY, iconSize, iconSize);
-						currentY += iconSize + iconSpacing;
-					}
-				}
-			}
-			ctx.drawImage(bottomImage, 0, 0, textBottomBarWidth, textBottomBarHeight, 0, maxHeight - bottomImageheight, maxWidth, bottomImageheight);
-		}
-	}
-
-	async function drawOrderCard(data, ctx) {
-		const maxFieldsHeight = maxHeight * 0.455;
-		const textPosition = maxHeight * 0.54;
-		const marginOrderWidth = maxHeight * 0.1;
-
-		let interline = maxHeight * 0.0077;
-		let fontSize = maxHeight * 0.03;
-
-		// Load images from paths
-		const picture = await loadImage(data.picture);
-
-		if (!data.hasText) {
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-		} else {
-
-			// Initial settings for margin and font size
-			let generalTextHeight = 0;
-			const generalTextWithFbElements = replaceForbiddenStarsElements(data.general)
-			const recalculateTextHeight = () => {
-				generalTextHeight = calculateTextHeight(ctx, generalTextWithFbElements, 0, marginOrderWidth, interline, fontSize);
-			};
-
-			const resizeAllShit = () => {
-				fontSize *= 0.95;
-				interline *= 0.97;
-				recalculateTextHeight();
-			};
-
-			recalculateTextHeight()
-			while (generalTextHeight > maxFieldsHeight) {
-				resizeAllShit();
-			};
-
-			const drawText = (text, yPosition) => {
-				ctx.font = `${fontSize}px ForbiddenStars`;
-				const words = text.split(' ');
-				let line = '';
-				let lineHeight = parseInt(ctx.font.match(/\d+/), 10);
-				yPosition += lineHeight;
-				for (let n = 0; n < words.length; n++) {
-					if (words[n] === "*newline*") {
-						ctx.fillText(line, maxWidth * 0.5, yPosition);
-						yPosition += lineHeight + interline;
-						line = '';
-					}
-					else if (words[n] === "*newpara*") {
-						yPosition += 2 * lineHeight;
-						line = '';
-					}
-					else {
-						const testLine = line + words[n] + ' ';
-						const metrics = ctx.measureText(testLine);
-						if (metrics.width > maxWidth - 2 * marginOrderWidth && n > 0) {
-							ctx.fillText(line, maxWidth * 0.5, yPosition);
-							yPosition += lineHeight + interline;
-							line = words[n] + ' ';
-						} else {
-							line = testLine;
-						};
-					};
-				};
-				ctx.fillText(line, maxWidth * 0.5, yPosition);
-			};
-
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-			ctx.font = `${titleFontSize}px Headline`;
-			ctx.textAlign = "center";
-			ctx.fillText(data.title, maxWidth * 0.5, maxHeight * 0.2325);
-
-			drawText(generalTextWithFbElements, textPosition);
-		}
-	}
-
-	async function drawEventCard(data, ctx) {
-		const maxFieldsHeight = maxHeight * 0.278;
-		const textPosition = maxHeight * 0.685;
-
-		let interline = maxHeight * 0.0077;
-		let fontSize = maxHeight * 0.03;
-
-		// Load images from paths
-		const picture = await loadImage(data.picture);
-
-		if (!data.hasText) {
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-		} else {
-			// Initial settings for margin and font size
-			let generalTextHeight = 0;
-			const generalTextWithFbElements = replaceForbiddenStarsElements(data.general);
-			const recalculateTextHeight = () => {
-				generalTextHeight = calculateTextHeight(ctx, generalTextWithFbElements, 20, 0, interline, fontSize);
-			};
-			const resizeAllShit = () => {
-				fontSize *= 0.95;
-				interline *= 0.97;
-				recalculateTextHeight()
-			};
-			recalculateTextHeight()
-			while (generalTextHeight > maxFieldsHeight) {
-				resizeAllShit();
-			};
-			const drawText = (ctx_, text, yPosition) => {
-				ctx_.font = `${fontSize}px ForbiddenStars`;
-				const words = text.split(' ');
-				let line = '';
-				let lineHeight = parseInt(ctx_.font.match(/\d+/), 10);
-				yPosition += lineHeight;
-				for (let n = 0; n < words.length; n++) {
-					if (words[n] === "*newline*") {
-						ctx_.fillText(line, marginWidth, yPosition);
-						yPosition += lineHeight + interline;
-						line = '';
-					}
-					else if (words[n] === "*newpara*") {
-						ctx_.fillText(line, marginWidth, yPosition);
-						yPosition += 2 * lineHeight;
-						line = '';
-					}
-					else {
-						const testLine = line + words[n] + ' ';
-						const metrics = ctx_.measureText(testLine);
-						if (metrics.width > maxWidth - 2 * marginWidth && n > 0) {
-							ctx_.fillText(line, marginWidth, yPosition);
-							yPosition += lineHeight + interline;
-							line = words[n] + ' ';
-						} else {
-							line = testLine;
-						};
-					};
-				};
-				ctx_.fillText(line, marginWidth, yPosition);
-			};
-
-			ctx.drawImage(picture, 0, 0, maxWidth, maxHeight);
-			ctx.font = `${titleFontSize * 0.8}px EventFont`;
-			ctx.textAlign = "center";
-			ctx.fillText(data.type, maxWidth * 0.5, maxHeight * 0.573);
-			ctx.font = `${titleFontSize}px Headline`;
-			ctx.textAlign = "left";
-			ctx.fillText(data.title, maxWidth * 0.05, maxHeight * 0.0735);
-			drawText(ctx, generalTextWithFbElements, textPosition);
-		}
-	}
-});
+    if (cat === 'combat') {
+      (man.combat || []).forEach(function (files, ti) {
+        var label = TIER_LABELS[ti] || ('Set ' + (ti + 1));
+        var tierTxt = txt && txt.combat ? txt.combat[ti] : null;
+        var cards = files.map(function (f, i) {
+          var t = tierTxt && tierTxt[i]
+            ? { title: tierTxt[i].title, background: tierTxt[i].general, foreground: tierTxt[i].unit, icons: tierTxt[i].icons }
+            : null;
+          return push(f, facName(fac) + ' · ' + label + ' ' + (i + 1), 'combat', t);
+        });
+        if (cards.length) groups.push({ label: label, sub: cards.length + ' cards', cards: cards });
+      });
+    } else {
+      var files = man[cat] || [];
+      var labels, kind = null, textList = null;
+      if (cat === 'backs') {
+        labels = files.map(function (f) { return BACK_LABELS[f.replace(/\.[a-z]+$/i, '')] || 'Card Back'; });
+      } else if (cat === 'faction_card') {
+        labels = files.map(function (_, i) { return facName(fac) + ' Reference' + (files.length > 1 ? ' ' + (i + 1) : ''); });
+      } else if (cat === 'map') {
+        labels = files.map(function (_, i) { return 'Map ' + String.fromCharCode(65 + i); });
+      } else if (cat === 'orders') {
+        labels = files.map(function (_, i) { return 'Order Upgrade ' + (i + 1); });
+        kind = 'orders'; textList = txt ? txt.orders : null;
+      } else { // events
+        labels = files.map(function (_, i) { return 'Event ' + (i + 1); });
+        kind = 'events'; textList = txt ? txt.events : null;
+      }
+      var cards = files.map(function (f, i) {
+        var t = (kind && textList && textList[i]) ? textList[i] : null;
+        return push(f, labels[i], kind, t);
+      });
+      if (cards.length) groups.push({ label: null, sub: '', cards: cards });
+    }
+    return { groups: groups, ready: true };
+  }
+
+  /* ---------------- lightbox ---------------- */
+
+  function openLb(idx) { setState({ lb: idx, lbFull: false }); }
+  function closeLb() { setState({ lb: null, lbFull: false }); }
+  function step(d) {
+    if (!flat.length || state.lb === null) return;
+    setState({ lb: (state.lb + d + flat.length) % flat.length, lbFull: false });
+  }
+
+  document.addEventListener('keydown', function (e) {
+    if (state.lb === null) return;
+    if (e.key === 'Escape') closeLb();
+    else if (e.key === 'ArrowRight') step(1);
+    else if (e.key === 'ArrowLeft') step(-1);
+  });
+
+  /* ---------------- render ---------------- */
+
+  function render() {
+    var acc = ACC[ACCENT] || ACC.amber;
+    var cols = Math.max(2, Math.min(8, density()));
+    var cat = state.category;
+
+    var built = build();
+    var groups = built.groups;
+
+    // grid geometry per category
+    var gridCols, gridJustify, cardAspect;
+    if (cat === 'faction_card') {
+      gridCols = 'repeat(1, minmax(0, 860px))'; gridJustify = 'center'; cardAspect = '1688 / 2000';
+    } else if (cat === 'map') {
+      gridCols = 'repeat(1, minmax(0, 920px))'; gridJustify = 'center'; cardAspect = '1 / 1';
+    } else {
+      gridCols = 'repeat(' + cols + ', minmax(0, 1fr))'; gridJustify = 'start'; cardAspect = '434 / 615';
+    }
+
+    var app = el('div', { class: 'fs-app', 'data-accent': ACCENT });
+
+    /* ---- header ---- */
+    var exptabs = el('div', { class: 'fs-exptabs fs-scroll' },
+      DATA.expansions.map(function (e) {
+        return el('button', {
+          class: 'fs-tab' + (state.expansion === e.key ? ' is-active' : ''),
+          onclick: (function (key) { return function () { selectExpansion(key); }; })(e.key),
+        }, [el('span', { text: e.name })]);
+      })
+    );
+    var header = el('header', { class: 'fs-header' }, [
+      el('div', { class: 'fs-brand' }, [
+        el('div', { class: 'fs-logo' }, [
+          el('div', { class: 'fs-logo-ring' }),
+          el('div', { class: 'fs-logo-core' }),
+        ]),
+        el('div', { class: 'fs-brand-text' }, [
+          el('span', { class: 'fs-brand-title', text: 'FORBIDDEN STARS' }),
+          el('span', { class: 'fs-brand-sub', text: 'Card Codex' }),
+        ]),
+      ]),
+      exptabs,
+    ]);
+
+    /* ---- sidebar ---- */
+    var nav = el('nav', { class: 'fs-nav' },
+      facList().map(function (f) {
+        var cnt = manifestCount(DATA.manifest[state.expansion + '/' + f.key]);
+        return el('button', {
+          class: 'fs-fac' + (state.faction === f.key ? ' is-active' : ''),
+          onclick: (function (key) { return function () { setState({ faction: key, lb: null }); }; })(f.key),
+        }, [
+          el('span', { class: 'fs-fac-dot', style: 'background:' + f.dot + ';' }),
+          el('span', { class: 'fs-fac-name', text: f.name }),
+          el('span', { class: 'fs-fac-count', text: cnt == null ? '' : String(cnt) }),
+        ]);
+      })
+    );
+    var sidebar = el('aside', { class: 'fs-sidebar' }, [
+      el('div', { class: 'fs-sidebar-label', text: 'Factions' }),
+      nav,
+      el('div', { class: 'fs-sidebar-foot' }, [
+        el('a', { class: 'fs-faq-link', href: 'faq_manuscript_page.html', text: 'FAQ & Rules' }),
+        el('p', { html: 'FAN PROJECT &middot; NON&#8209;COMMERCIAL<br>Artwork &copy; Games Workshop' }),
+      ]),
+    ]);
+
+    /* ---- main ---- */
+    var main = el('main', { class: 'fs-main' });
+
+    var cattabs = el('div', { class: 'fs-cattabs fs-scroll' },
+      DATA.categories.map(function (c) {
+        return el('button', {
+          class: 'fs-cat' + (cat === c.key ? ' is-active' : ''),
+          onclick: (function (key) { return function () { setState({ category: key, lb: null }); }; })(c.key),
+          text: catName(c.key),
+        });
+      })
+    );
+    main.appendChild(el('div', { class: 'fs-cattabs-wrap' }, [cattabs]));
+
+    main.appendChild(el('div', { class: 'fs-breadcrumb' }, [
+      el('div', { class: 'fs-bc-left' }, [
+        el('span', { class: 'fs-bc-exp', text: expName(state.expansion) }),
+        el('span', { class: 'fs-bc-sep', text: '/' }),
+        el('h1', { class: 'fs-bc-title', text: (facName(state.faction) || '…') + ' — ' + catName(cat) }),
+      ]),
+      el('span', {
+        class: 'fs-bc-total',
+        text: cat === 'material'
+          ? ((built.material && built.material.length ? built.material.length + ' units' : ''))
+          : (flat.length + ' ' + (flat.length === 1 ? 'card' : 'cards')),
+      }),
+    ]));
+
+    var scrollarea = el('div', { class: 'fs-scrollarea fs-scroll' });
+    if (!built.ready) {
+      scrollarea.appendChild(el('div', { class: 'fs-note', text: 'Loading…' }));
+    } else if (cat === 'material') {
+      scrollarea.appendChild(renderMaterial(built.material));
+    } else if (!groups.length) {
+      scrollarea.appendChild(el('div', { class: 'fs-note', text: 'No cards of this type in this set.' }));
+    } else {
+      groups.forEach(function (group) {
+        if (group.label) {
+          scrollarea.appendChild(el('div', { class: 'fs-group-head' }, [
+            el('span', { class: 'fs-group-label', text: group.label }),
+            el('span', { class: 'fs-group-rule' }),
+            el('span', { class: 'fs-group-sub', text: group.sub }),
+          ]));
+        }
+        var grid = el('div', {
+          class: 'fs-grid',
+          style: 'grid-template-columns:' + gridCols + ';justify-content:' + gridJustify + ';',
+        }, group.cards.map(function (card) {
+          var btn = el('button', {
+            class: 'fs-card',
+            title: card.label,
+            style: 'aspect-ratio:' + cardAspect + ';',
+            onclick: (function (idx) { return function () { openLb(idx); }; })(card.index),
+          }, [
+            el('img', { src: card.src, alt: card.label, loading: 'lazy' }),
+          ]);
+          var imgEl = btn.querySelector('img');
+          // hide the whole card if its artwork fails to load (e.g. a set without maps);
+          // if that empties the whole view, surface a note instead of a blank panel
+          imgEl.addEventListener('error', function () {
+            btn.style.display = 'none';
+            maybeEmptyNote(scrollarea);
+          });
+          applyComposite(imgEl, card);
+          return btn;
+        }));
+        scrollarea.appendChild(grid);
+      });
+    }
+    main.appendChild(scrollarea);
+
+    app.appendChild(header);
+    app.appendChild(el('div', { class: 'fs-body' }, [sidebar, main]));
+
+    /* ---- lightbox ---- */
+    if (state.lb !== null) {
+      var c = flat[state.lb];
+      if (c) {
+        var bigFormat = cat === 'faction_card' || cat === 'map';
+        var full = bigFormat && state.lbFull;
+        var children = [
+          el('button', {
+            class: 'fs-lb-nav', 'aria-label': 'Previous card', html: '&lsaquo;',
+            onclick: function (e) { e.stopPropagation(); step(-1); },
+          }),
+          el('figure', { class: 'fs-lb-fig' + (full ? ' is-full' : ''), onclick: function (e) { e.stopPropagation(); } }, [
+            lbImg(c),
+            el('figcaption', { class: 'fs-lb-cap' }, [
+              el('span', { class: 'fs-lb-label', text: c.label }),
+              el('span', {
+                class: 'fs-lb-meta',
+                text: catName(cat) + ' · ' + facName(state.faction) + ' · ' + (state.lb + 1) + ' / ' + flat.length,
+              }),
+            ]),
+          ]),
+          el('button', {
+            class: 'fs-lb-nav', 'aria-label': 'Next card', html: '&rsaquo;',
+            onclick: function (e) { e.stopPropagation(); step(1); },
+          }),
+          bigFormat ? el('button', {
+            class: 'fs-lb-full', 'aria-label': full ? 'Exit full screen' : 'Full screen',
+            title: full ? 'Exit full screen' : 'Full screen', html: full ? '&#10532;' : '&#10530;',
+            onclick: function (e) { e.stopPropagation(); setState({ lbFull: !state.lbFull }); },
+          }) : null,
+          el('button', {
+            class: 'fs-lb-close', 'aria-label': 'Close', html: '&#10005;',
+            onclick: function (e) { e.stopPropagation(); closeLb(); },
+          }),
+        ];
+        app.appendChild(el('div', { class: 'fs-lb', onclick: closeLb }, children));
+      }
+    }
+
+    var root = document.getElementById('app');
+    root.innerHTML = '';
+    root.appendChild(app);
+  }
+
+  function selectExpansion(key) {
+    ensureFactions(key);
+    var list = DATA.factions[key];
+    // keep current faction if it exists in the target expansion, else first/null
+    var keep = list && findKey(list, state.faction) ? state.faction : (list && list[0] ? list[0].key : null);
+    setState({ expansion: key, faction: keep, lb: null });
+  }
+
+  // Re-render on resize (debounced) so the column count tracks the viewport.
+  var _rt;
+  window.addEventListener('resize', function () {
+    clearTimeout(_rt);
+    _rt = setTimeout(render, 120);
+  });
+
+  /* ---------------- boot ---------------- */
+
+  function boot() {
+    fetchJSON('factions/general.json').then(function (g) {
+      DATA.general = g;
+      DATA.defaults = g.filenames;
+      DATA.expansions = (g.expansion.folder || []).map(function (key, i) {
+        return { key: key, name: (g.expansion.name && g.expansion.name[i]) || key };
+      });
+      DATA.categories = (g.cardsDefault.reference || []).map(function (key, i) {
+        return { key: key, name: (g.cardsDefault.name && g.cardsDefault.name[i]) || key };
+      });
+      state.expansion = DATA.expansions[0] ? DATA.expansions[0].key : null;
+      render();
+      if (state.expansion) ensureFactions(state.expansion);
+    }).catch(function (e) {
+      console.error(e);
+      var root = document.getElementById('app');
+      if (root) root.textContent = 'Failed to load card data.';
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+})();

--- a/page/style/styles.css
+++ b/page/style/styles.css
@@ -1,499 +1,354 @@
+/* Forbidden Stars — Card Codex
+   Ported from the "Forbidden Stars Codex" Claude Design component.
+   Pure static CSS, no build step. Desktop-first 100vh app shell. */
+
+/* Custom game fonts — used by the canvas card-text compositor (cardrender.js)
+   to draw rules text / titles / glyph icons onto template card art. */
 @font-face {
-    font-family: 'Headline';
-    src: url('../fonts/Headline.woff2') format('woff2');
+  font-family: 'Headline';
+  src: url('../fonts/Headline.woff2') format('woff2');
+  font-display: swap;
+}
+@font-face {
+  font-family: 'ForbiddenStars';
+  src: url('../fonts/ForbiddenStars.woff2') format('woff2');
+  font-display: swap;
+}
+@font-face {
+  font-family: 'EventFont';
+  src: url('../fonts/EventFont.woff2') format('woff2');
+  font-display: swap;
 }
 
-@font-face {
-    font-family: 'ForbiddenStars';
-    src: url('../fonts/ForbiddenStars.woff2') format('woff2');
-}
+* { box-sizing: border-box; }
 
-@font-face {
-    font-family: 'EventFont';
-    src: url('../fonts/EventFont.woff2') format('woff2');
-}
-
-:root {
-  --text:#bbb;
-  --text_2:#222;
-  --text_3: #000;
-  --background:#999;
-  --background_2:#222;
-  --background_3:#777;
-  --highlight: #aa6;
-  --spinnerColor: #36f;
-  --blue:rgba(47, 95, 255, 0.5);
-  --border:1px solid rgba(0, 0, 100, 0.5);
-  --max-width:1040px;
-  --content-width:940px;
+html, body {
+  margin: 0;
+  padding: 0;
+  background: #121110;
 }
 
 body {
-    top: 0;
-    display: flex;
-    flex-direction: column;
-    font-family: 'Headline';
-    width: 1420px;
-    min-height: 100vh;
-    gap: 5px;
-    color: var(--text);
-    background: var(--background);
+  color: #ece8e1;
+  font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+::selection { background: rgba(216, 166, 87, 0.28); }
+
+/* ---- scrollbars ---- */
+.fs-scroll::-webkit-scrollbar { width: 10px; height: 10px; }
+.fs-scroll::-webkit-scrollbar-thumb {
+  background: #2c2925;
+  border-radius: 8px;
+  border: 2px solid #121110;
+}
+.fs-scroll::-webkit-scrollbar-thumb:hover { background: #3a3631; }
+.fs-scroll::-webkit-scrollbar-track { background: transparent; }
+
+/* ---- animations ---- */
+@keyframes fsfade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes fspop  { from { opacity: 0; transform: scale(.965); } to { opacity: 1; transform: scale(1); } }
+
+/* ---- accent themes (set via [data-accent] on .fs-app) ---- */
+.fs-app {
+  --fs-accent: oklch(0.80 0.12 80);
+  --fs-accent-fg: #1c1810;
+}
+.fs-app[data-accent="amber"]   { --fs-accent: oklch(0.80 0.12 80);  --fs-accent-fg: #1c1810; }
+.fs-app[data-accent="steel"]   { --fs-accent: oklch(0.72 0.10 232); --fs-accent-fg: #0b1019; }
+.fs-app[data-accent="crimson"] { --fs-accent: oklch(0.62 0.185 25); --fs-accent-fg: #1c0d0c; }
+
+/* ---- app shell ---- */
+.fs-app {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: #121110;
+  color: #ece8e1;
+  overflow: hidden;
+}
+
+/* ---- header ---- */
+.fs-header {
+  display: flex;
+  align-items: center;
+  gap: 26px;
+  padding: 0 22px;
+  height: 60px;
+  border-bottom: 1px solid #2c2925;
+  background: #16140f;
+  flex-shrink: 0;
+  z-index: 10;
+}
+.fs-brand { display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
+.fs-logo { position: relative; width: 24px; height: 24px; flex-shrink: 0; }
+.fs-logo-ring {
+  position: absolute; inset: 2px; transform: rotate(45deg);
+  border: 1.5px solid var(--fs-accent); border-radius: 3px;
+}
+.fs-logo-core {
+  position: absolute; left: 50%; top: 50%; width: 6px; height: 6px;
+  margin: -3px 0 0 -3px; background: var(--fs-accent); transform: rotate(45deg);
+}
+.fs-brand-text { display: flex; flex-direction: column; line-height: 1.1; }
+.fs-brand-title { font-size: 14.5px; font-weight: 700; letter-spacing: 0.16em; }
+.fs-brand-sub {
+  font-family: 'IBM Plex Mono', monospace; font-size: 9px; letter-spacing: 0.34em;
+  color: #857f74; text-transform: uppercase; margin-top: 2px;
+}
+
+.fs-exptabs {
+  display: flex; align-items: center; gap: 3px;
+  overflow-x: auto; margin-left: 4px;
+}
+
+/* ---- generic tab (expansion bar) ---- */
+.fs-tab {
+  appearance: none; border: none; cursor: pointer; font-family: inherit;
+  font-size: 12.5px; font-weight: 500; letter-spacing: 0.01em;
+  padding: 7px 13px; border-radius: 8px; white-space: nowrap;
+  display: inline-flex; align-items: center;
+  background: transparent; color: #8a847a;
+  transition: background .15s, color .15s;
+}
+.fs-tab:hover { color: #c4bdb1; }
+.fs-tab.is-active {
+  font-weight: 600; background: var(--fs-accent); color: var(--fs-accent-fg);
+}
+.fs-tab-soon {
+  margin-left: 8px; font-family: 'IBM Plex Mono', monospace; font-size: 8px;
+  letter-spacing: 0.12em; opacity: 0.55;
 }
 
+/* ---- body row ---- */
+.fs-body { flex: 1; display: flex; min-height: 0; }
 
-@keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
-
-    100% {
-        transform: rotate(360deg);
-    }
-}
-
-.card-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-family: 'EventFont';
-    width: 450px;
-    height: 650px;
-    color: var(--text);
-    font-size: 25px;
-    background-color: var(--background_2);
-    border-radius: 8px;
-}
-
-.card-placeholder .card-spinner {
-    border: var(--border);
-    border-top: 4px solid var(--spinnerColor);
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    animation: spin 1s linear infinite;
-}
-
-#expansion-tabs {
-    font-size: 30px;
-    width: 100%;
-}
-
-#faction-tabs {
-    font-size: 28px;
-    width: 100%;
-}
-
-#cards-tabs {
-    font-size: 26px;
-    width: 100%;
-}
-
-.expansion-header,
-.faction-header,
-.card-header {
-    border-radius:12px;
-    display: inline-block;
-    padding: 5px 8px 8px 8px;
-    background-color: var(--background_2);
-    z-index: 1000;
-    cursor: grab;
-    letter-spacing: .01em;
-    margin: 1px;
-}
-
-.expansion-header.active,
-.faction-header.active {
-    background-color: var(--background_3);
-    color: var(--text_2);
-    box-shadow: 0 0 30px #f80;
-    cursor: default;
-}
-
-.card-header.active {
-    background-color: var(--background_3);
-    box-shadow: 0 0 10px #090;
-    color: var(--text_2);
-    cursor: default;
-}
-
-.card-container {
-    display: none;
-}
-
-.card-container.active {
-    display: block;
-}
-
-#faq-container {
-    display: none;
-    width: 100%;
-    position: relative;
-    flex: 1;
-}
-
-#faq-container.active {
-    display: flex;
-    flex-direction: column;
-}
-
-.faq-page-shell {
-    position: relative;
-    width: 100%;
-    min-height: 100vh;
-    color: var(--text_2);
-}
-
-.faq-header-panel {
-    position: sticky;
-    top: 12px;
-    z-index: 20;
-    max-width: var(--max-width);
-    margin: 0 auto 24px;
-    padding: 14px;
-    background-color: var(--background_2);
-    color: var(--text);
-    border-radius: 18px;
-    opacity: 0.85;
-}
-
-.faq-search-wrap {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    flex-wrap: wrap;
-}
-
-.faq-search-box {
-    flex: 1 1 340px;
-    min-width: 260px;
-    padding: 14px 18px;
-    border-radius: 12px;
-    border: var(--border);
-    background-color: var(--background);
-    font-size: 16px;
-    font-family: 'ForbiddenStars';
-    outline: none;
-}
-
-.faq-search-meta {
-    font-size: 14px;
-    border-radius: 12px;
-    font-family: 'ForbiddenStars';
-}
-
-.faq-content {
-    position: relative;
-    max-width: var(--content-width);
-    margin: 0 auto;
-    padding: 50px 30px 200px 15px;
-    border-radius: 24px;
-    overflow: hidden;
-}
-
-.faq-empty-state {
-    padding: 24px 0;
-    font-size: 18px;
-    text-align: center;
-    opacity: 0.8;
-}
-
-.faq-level-block {
-    margin: 0 0 28px;
-}
-
-.faq-level-row {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(180px, 280px);
-    gap: 18px;
-    align-items: start;
-}
-
-.faq-level-row.no-picture {
-    grid-template-columns: 1fr;
-}
-
-.faq-level-image {
-    max-width: 100px;
-    border-radius: 10px;
-    border: var(--border);
-    display: block;
-    justify-self: end;
-}
-
-.faq-content h1,
-.faq-content h2,
-.faq-content h3 {
-    margin: 0;
-    line-height: 1.15;
-    font-family: 'EventFont';
-    letter-spacing: 0.01em;
-}
-
-.faq-phrase-title,
-.faq-main-text {
-    font-family: 'ForbiddenStars';
-}
-
-.faq-content h1 {
-    font-size: clamp(30px, 4vw, 44px);
-    margin-bottom: 10px;
-}
-
-.faq-content h2 {
-    font-size: clamp(24px, 3vw, 34px);
-    margin-bottom: 8px;
-}
-
-.faq-content h3 {
-    font-size: clamp(22px, 2.8vw, 30px);
-    margin-bottom: 8px;
-}
-
-.faq-separator {
-    width: 100%;
-    height: 3px;
-    background: linear-gradient(to right, transparent, var(--blue), transparent);
-    margin: 0 0 16px;
+/* ---- sidebar ---- */
+.fs-sidebar {
+  width: 236px; flex-shrink: 0; border-right: 1px solid #2c2925;
+  background: #16140f; display: flex; flex-direction: column; padding: 18px 14px;
 }
-
-.faq-category-block {
-    margin-bottom: 42px;
-}
-
-.faq-subcategory-block {
-    margin: 22px 0 28px;
-    padding-left: 10px;
-}
-
-.faq-faction-block {
-    margin: 18px 0 24px;
-    padding-left: 12px;
-}
-
-.faq-phrase-block {
-    margin: 14px 0 16px;
-    padding: 14px 16px;
-    border-radius: 14px;
-    background: var(--background);
-    border: var(--border);
-}
-
-.faq-phrase-title {
-    display: block;
-    font-weight: 700;
-    font-size: 18px;
-    margin-bottom: 8px;
-    color: var(--text_3);
-}
-
-.faq-main-text {
-    font-size: 17px;
-    line-height: 1.7;
-    white-space: pre-wrap;
-    word-break: break-word;
-}
-
-.faq-content mark {
-    background: var(--highlight);
-    color: inherit;
-    padding: 0 0.1em;
-    border-radius: 0.15em;
-}
-
-.grid {
-    display: grid;
-    gap: 20px 20px;
-    grid-template-columns: repeat(3, 1fr);
-    background-color: var(--background_3);
-    gap: 5px 5px;
-    padding: 10px;
-}
-
-.grid.events {
-    grid-template-columns: repeat(4, 1fr);
-    width: 1835px;
-}
-
-.grid.cardBackImages {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 5px 5px;
-}
-
-.grid.factionCardImage {
-    grid-template-columns: repeat(1, 1fr);
-    width: 1835px;
-}
-
-.grid.mapImages {
-    grid-template-columns: repeat(2, 1fr);
-    width: 1835px;
-}
-
-.grid.materials {
-    grid-template-columns: repeat(1, 1fr);
-    width: 100%;
-}
-
-.material-card {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    padding: 24px;
-    border-radius: 18px;
-    background: rgba(0, 0, 0, 0.24);
-    border: var(--border);
-    min-height: 450px;
-}
-
-.material-heading {
-    font-family: 'EventFont';
-    font-size: 36px;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--text_2);
-    border-bottom: 2px solid var(--highlight);
-    padding-bottom: 8px;
-}
-
-.material-body {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    font-family: 'ForbiddenStars';
-    font-size: 22px;
-    line-height: 1.6;
-    color: var(--text);
-}
-
-.material-line {
-    display: block;
-    padding: 10px 14px;
-    border-radius: 12px;
-    background: rgba(255, 255, 255, 0.06);
-    white-space: normal;
-    word-break: break-word;
-}
-
-.material-label {
-    font-weight: 700;
-    display: inline-block;
-    margin-right: 8px;
-}
-
-.material-value {
-    display: inline;
-}
-
-.material-empty {
-    margin: 0;
-    opacity: 0.8;
-    font-size: 20px;
-}
-
-
-.grid.orders {
-    grid-template-columns: repeat(3, 1fr);
-}
-
-.grid.combat.s-section {
-    background-color: #090;
-}
-
-.grid.combat.t1-section {
-    background-color: #990;
-}
-
-.grid.combat.t2-section {
-    background-color: #950;
+.fs-sidebar-label {
+  font-family: 'IBM Plex Mono', monospace; font-size: 10px; letter-spacing: 0.26em;
+  color: #857f74; text-transform: uppercase; padding: 0 8px 12px;
 }
+.fs-nav { display: flex; flex-direction: column; gap: 3px; }
 
-.grid.combat.t3-section {
-    background-color: #900;
+.fs-fac {
+  display: flex; align-items: center; gap: 11px; width: 100%; text-align: left;
+  appearance: none; border: 1px solid transparent; background: transparent;
+  cursor: pointer; font-family: inherit; color: #b3ada3; font-size: 13.5px;
+  font-weight: 500; padding: 9px 11px; border-radius: 10px; transition: all .15s;
 }
-
-.faction-header.active[data-faction="space_marines"] {
-    background-color: #66f;
-    box-shadow: 0 0 5px #66f;
+.fs-fac:hover { background: #1d1b18; }
+.fs-fac.is-active {
+  border: 1px solid #34302a; background: #221f1a; color: #f3efe8; font-weight: 600;
+  box-shadow: inset 2px 0 0 var(--fs-accent);
 }
-
-.faction-header.active[data-faction="chaos"] {
-    background-color: #e11;
-    box-shadow: 0 0 5px #f55;
+.fs-fac-dot {
+  width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.035);
 }
+.fs-fac-name { flex: 1; }
+.fs-fac-count { font-family: 'IBM Plex Mono', monospace; font-size: 10px; color: #6f6a61; }
 
-.faction-header.active[data-faction="ork"] {
-    background-color: #2f3;
-    box-shadow: 0 0 5px #2f4;
+.fs-sidebar-foot {
+  margin-top: auto; padding: 14px 8px 2px; border-top: 1px solid #221f1a;
 }
-
-.faction-header.active[data-faction="eldar"] {
-    background-color: #ff1;
-    box-shadow: 0 0 5px #ff1;
+.fs-sidebar-foot p {
+  font-family: 'IBM Plex Mono', monospace; font-size: 9px; line-height: 1.7;
+  color: #5c574f; margin: 0; letter-spacing: 0.05em;
 }
-
-.faction-header.active[data-faction="ig"] {
-    background-color: #999;
-    color: #050;
-    box-shadow: 0 0 5px #ccc;
+.fs-faq-link {
+  display: inline-block; margin-bottom: 10px;
+  font-family: 'IBM Plex Mono', monospace; font-size: 10px; letter-spacing: 0.18em;
+  text-transform: uppercase; color: #857f74; text-decoration: none;
+  transition: color .15s;
 }
+.fs-faq-link:hover { color: var(--fs-accent); }
 
-.faction-header.active[data-faction="tyranid"] {
-    background-color: #b3f;
-    box-shadow: 0 0 5px #c4f;
-}
+/* ---- main ---- */
+.fs-main { flex: 1; min-width: 0; display: flex; flex-direction: column; }
 
-.faction-header.active[data-faction="necron"] {
-    background-color: #000;
-    color: #2f1;
-    box-shadow: 0 0 5px #2f1;
+.fs-cattabs-wrap {
+  padding: 0 26px; border-bottom: 1px solid #2c2925; background: #141310; flex-shrink: 0;
 }
-
-.faction-header.active[data-faction="tau"] {
-    background-color: #fa1;
-    box-shadow: 0 0 5px #fa1;
+.fs-cattabs { display: flex; gap: 2px; overflow-x: auto; }
+.fs-cat {
+  appearance: none; border: none; background: transparent; cursor: pointer;
+  font-family: inherit; font-size: 13px; font-weight: 500; color: #8a847a;
+  padding: 13px 15px; border-bottom: 2px solid transparent; white-space: nowrap;
+  transition: color .15s, border-color .15s;
 }
-
-.faction-header.active[data-faction="adeptus_mechanicus"] {
-    background-color: #a52;
-    box-shadow: 0 0 5px #a52;
+.fs-cat:hover { color: #c4bdb1; }
+.fs-cat.is-active {
+  font-weight: 600; color: #f3efe8; border-bottom: 2px solid var(--fs-accent);
 }
 
-.faction-header.active[data-faction="adepta_sororitas"] {
-    background-color: #fff;
-    box-shadow: 0 0 5px #fff;
-    color: #000;
+.fs-breadcrumb {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  padding: 17px 26px 5px; flex-shrink: 0;
 }
-
-.faction-header.active[data-faction="dark_eldar"] {
-    background-color: #1ed;
-    box-shadow: 0 0 5px #1ed;
-    color: #000;
+.fs-bc-left { display: flex; align-items: center; gap: 11px; min-width: 0; }
+.fs-bc-exp {
+  font-family: 'IBM Plex Mono', monospace; font-size: 10px; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--fs-accent); white-space: nowrap;
 }
-
-.faction-header.active[data-faction="inquisition"] {
-    background-color: #80f;
-    box-shadow: 0 0 5px #80f;
-    color: #fff;
+.fs-bc-sep { color: #3a352f; }
+.fs-bc-title {
+  font-size: 16px; font-weight: 600; margin: 0; color: #f3efe8;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-
-.faction-header.active[data-faction="worldeaters"] {
-    background-color: #f33;
-    box-shadow: 0 0 5px #f55;
+.fs-bc-total {
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #857f74;
+  letter-spacing: 0.08em; white-space: nowrap;
 }
 
-.faction-header.active[data-faction="thousandsons"] {
-    background-color: #22f;
-    color: #cc2;
-    box-shadow: 0 0 5px #22f;
-}
+.fs-scrollarea { flex: 1; min-height: 0; overflow-y: auto; padding: 18px 26px 44px; }
 
-.faction-header.active[data-faction="emperorschildren"] {
-    background-color: #d2a;
-    box-shadow: 0 0 5px #d2a;
-}
+.fs-group-head { display: flex; align-items: center; gap: 13px; margin: 8px 0 16px; }
+.fs-group-label {
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px; font-weight: 500;
+  letter-spacing: 0.18em; text-transform: uppercase; color: #bdb7ac; white-space: nowrap;
+}
+.fs-group-rule { height: 1px; flex: 1; background: linear-gradient(90deg, #2c2925, transparent); }
+.fs-group-sub {
+  font-family: 'IBM Plex Mono', monospace; font-size: 10px; color: #6f6a61; white-space: nowrap;
+}
+
+.fs-grid { display: grid; gap: 18px; margin-bottom: 30px; }
 
-.faction-header.active[data-faction="deathguard"] {
-    background-color: #351;
-    color: #aa0;
-    box-shadow: 0 0 5px #351;
+.fs-note {
+  font-family: 'IBM Plex Mono', monospace; font-size: 12px; letter-spacing: 0.04em;
+  color: #7a746a; padding: 30px 4px;
+}
+
+/* ---- Unit Count (material) table ---- */
+.fs-material-card {
+  max-width: 520px;
+  display: flex; flex-direction: column; gap: 14px;
+  padding: 22px 22px 24px; border-radius: 16px;
+  background: #1a1815; border: 1px solid #2c2925;
+}
+.fs-material-heading {
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px; font-weight: 500;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fs-accent);
+  border-bottom: 1px solid #2c2925; padding-bottom: 11px;
+}
+.fs-material-body { display: flex; flex-direction: column; gap: 6px; }
+.fs-material-line {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  padding: 10px 13px; border-radius: 9px; background: rgba(255, 255, 255, 0.035);
+  font-size: 14px;
+}
+.fs-material-label { color: #d8d2c8; font-weight: 500; }
+.fs-material-value {
+  font-family: 'IBM Plex Mono', monospace; font-size: 14px; font-weight: 600;
+  color: var(--fs-accent); min-width: 28px; text-align: right;
+}
+
+.fs-card {
+  appearance: none; padding: 0; margin: 0; cursor: zoom-in; background: #1e1c1a;
+  border: 1px solid #2c2925; border-radius: 12px; overflow: hidden; width: 100%;
+  display: block; position: relative;
+  transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease;
+}
+.fs-card:hover {
+  border-color: var(--fs-accent); transform: translateY(-5px);
+  box-shadow: 0 14px 34px -10px rgba(0, 0, 0, .78);
+}
+.fs-card img { width: 100%; height: 100%; object-fit: cover; display: block; }
+
+/* ---- unavailable state ---- */
+.fs-empty {
+  flex: 1; display: flex; flex-direction: column; align-items: center;
+  justify-content: center; gap: 18px; padding: 40px; text-align: center;
+}
+.fs-empty-glyph { position: relative; width: 54px; height: 54px; opacity: 0.85; }
+.fs-empty-glyph .ring {
+  position: absolute; inset: 4px; transform: rotate(45deg);
+  border: 1.5px solid #3a3631; border-radius: 6px;
+}
+.fs-empty-glyph .core {
+  position: absolute; left: 50%; top: 50%; width: 12px; height: 12px;
+  margin: -6px 0 0 -6px; background: #2c2925; transform: rotate(45deg);
+}
+.fs-empty-stack { display: flex; flex-direction: column; gap: 7px; align-items: center; }
+.fs-empty h2 {
+  font-size: 19px; font-weight: 600; margin: 0; color: #e6e1d8; letter-spacing: 0.01em;
+}
+.fs-empty p {
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px; line-height: 1.8;
+  color: #7a746a; margin: 0; max-width: 380px; letter-spacing: 0.03em;
+}
+.fs-empty-btn {
+  appearance: none; cursor: pointer; font-family: inherit; font-size: 12.5px;
+  font-weight: 600; letter-spacing: 0.02em; color: var(--fs-accent-fg);
+  background: var(--fs-accent); border: none; border-radius: 9px; padding: 10px 18px;
+  transition: opacity .15s;
+}
+.fs-empty-btn:hover { opacity: 0.9; }
+
+/* ---- lightbox ---- */
+.fs-lb {
+  position: fixed; inset: 0; z-index: 60; background: rgba(8, 7, 6, .88);
+  backdrop-filter: blur(7px); -webkit-backdrop-filter: blur(7px);
+  display: flex; align-items: center; justify-content: center; gap: 18px;
+  padding: 32px; animation: fsfade .18s ease;
+}
+.fs-lb-nav {
+  width: 46px; height: 46px; flex-shrink: 0; border-radius: 50%;
+  border: 1px solid #38332c; background: rgba(30, 28, 26, .85); color: #d8d2c8;
+  font-size: 24px; line-height: 1; cursor: pointer; display: flex;
+  align-items: center; justify-content: center; transition: all .15s;
+}
+.fs-lb-nav:hover { border-color: var(--fs-accent); color: var(--fs-accent); }
+.fs-lb-fig {
+  margin: 0; display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: fspop .2s ease;
+}
+.fs-lb-fig img {
+  max-height: 80vh; max-width: min(640px, 80vw); border-radius: 14px;
+  border: 1px solid #38332c; box-shadow: 0 40px 90px -25px #000; display: block;
+}
+.fs-lb-cap { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+.fs-lb-label { font-size: 15px; font-weight: 600; color: #f3efe8; }
+.fs-lb-meta {
+  font-family: 'IBM Plex Mono', monospace; font-size: 10.5px; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--fs-accent);
+}
+.fs-lb-close, .fs-lb-full {
+  position: absolute; top: 22px; width: 38px; height: 38px;
+  border-radius: 50%; border: 1px solid #38332c; background: rgba(30, 28, 26, .85);
+  color: #b3ada3; font-size: 15px; line-height: 1; cursor: pointer; display: flex;
+  align-items: center; justify-content: center; transition: all .15s;
+}
+.fs-lb-close { right: 24px; }
+.fs-lb-full { right: 70px; font-size: 16px; }
+.fs-lb-close:hover, .fs-lb-full:hover { border-color: var(--fs-accent); color: #f3efe8; }
+
+/* full-screen mode: image fills the viewport vertically, caption hidden */
+.fs-lb-fig.is-full { gap: 0; }
+.fs-lb-fig.is-full img { max-height: 96vh; max-width: 94vw; border-radius: 8px; }
+.fs-lb-fig.is-full .fs-lb-cap { display: none; }
+
+/* ---- responsive ---- */
+@media (max-width: 900px) {
+  .fs-sidebar { width: 188px; }
+}
+@media (max-width: 720px) {
+  .fs-app { height: auto; min-height: 100vh; overflow: visible; }
+  .fs-body { flex-direction: column; }
+  .fs-sidebar {
+    width: 100%; border-right: none; border-bottom: 1px solid #2c2925;
+    flex-direction: row; flex-wrap: wrap; align-items: center; gap: 8px; padding: 12px 14px;
+  }
+  .fs-sidebar-label { display: none; }
+  .fs-nav { flex-direction: row; flex-wrap: wrap; flex: 1; }
+  .fs-fac { width: auto; }
+  .fs-fac-count { display: none; }
+  .fs-sidebar-foot { display: none; }
+  .fs-scrollarea { overflow-y: visible; }
+  .fs-header { gap: 14px; padding: 0 14px; }
+  .fs-grid { gap: 12px; }
 }


### PR DESCRIPTION
Reapplies the Card Codex redesign on top of current `main` (the earlier merge was reverted) and integrates the **Unit Count** feature that landed since.

## What's in it
- **New UI shell** (vanilla HTML/CSS/JS, no build): expansion tab bar, faction sidebar with colour dots + counts, category tabs, responsive grouped card grid, click-to-zoom **lightbox** (prev/next, Esc/arrow keys, full-screen toggle for large formats).
- **All expansions browsable** — data-driven from `general.json` + per-expansion `faction.json`: Base, Galaxy in Flames, Symphony of War, The Dying Light, Darkest Dawn, every faction. Per-faction `text.json` filename overrides; missing artwork drops out cleanly with a note.
- **Card-text compositor** (`cardrender.js`) — draws title/body/type/icon glyphs with the FFG fonts onto template art (e.g. Symphony of War) for combat/orders/events, in grid and lightbox.
- **Unit Count** category — renders each faction's `materialsText` as a themed table.
- Faction Card + Maps shown large; grid density tuned for legibility.

Replaces the legacy codex UI in `index.html`/`script.js`/`styles.css`. Faction data + FAQ unchanged (FAQ linked from the sidebar).

Verified in-browser: all expansions/factions/categories, lightbox + keyboard, full-screen, Symphony text compositing, Unit Count table, responsive widths — no console errors beyond expected optional-`text.json` 404 probes.