### PR TITLE
In-app FAQ, magnifier loupe, larger zoom & faction-card aspect fixes

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -21,6 +21,7 @@
 <body>
     <div id="app"></div>
     <script src="script/cardrender.js"></script>
+    <script src="script/faq.js"></script>
     <script src="script/script.js"></script>
 </body>
 

--- a/page/script/faq.js
+++ b/page/script/faq.js
@@ -1,0 +1,50 @@
+/* Forbidden Stars — Field Manual / FAQ.
+ * Look ported from the "Forbidden Stars FAQ" Claude Design; CONTENT comes from
+ * the real data/FAQ.json (same source as the legacy faq_manuscript_page).
+ *
+ * FAQ.json shape:  [ {Category, items:[ {SubCategory, items:[ {Faction, picture,
+ *   items:[ {Phrase, Main} ] } ] } ] } ]
+ * We surface each Category as a sidebar topic and flatten the {Phrase, Main}
+ * pairs into accordion questions (SubCategory used as the tag). */
+(function () {
+  'use strict';
+
+  var DOTS = [
+    'oklch(0.80 0.12 80)', 'oklch(0.64 0.12 245)', 'oklch(0.66 0.15 142)',
+    'oklch(0.57 0.19 25)', 'oklch(0.80 0.13 90)', 'oklch(0.70 0.04 60)',
+  ];
+
+  window.FS_FAQ = {
+    src: 'data/FAQ.json',
+    hero: {
+      kicker: 'Rules Reference & Clarifications',
+      title: 'Frequently Asked Questions',
+      blurb: 'Official rules clarifications and answers to the questions that come up most at the table, across the base game and its expansions. Filter by section on the left or search above.',
+    },
+    dots: DOTS,
+
+    // raw FAQ.json -> { topics:[{key,name,dot}], qa:[{t,q,a,tag}] }
+    flatten: function (raw) {
+      var topics = [{ key: 'all', name: 'All Questions', dot: DOTS[0] }];
+      var qa = [];
+      (raw || []).forEach(function (cat, ci) {
+        var key = 'c' + ci;
+        topics.push({ key: key, name: cat.Category || ('Section ' + (ci + 1)), dot: DOTS[(ci + 1) % DOTS.length] });
+        (cat.items || []).forEach(function (sub) {
+          (sub.items || []).forEach(function (fac) {
+            (fac.items || []).forEach(function (it) {
+              if (!it || !it.Phrase) return;
+              qa.push({
+                t: key,
+                q: it.Phrase,
+                a: it.Main || '',
+                tag: sub.SubCategory || fac.Faction || null,
+              });
+            });
+          });
+        });
+      });
+      return { topics: topics, qa: qa };
+    },
+  };
+})();

--- a/page/script/script.js
+++ b/page/script/script.js
@@ -61,10 +61,28 @@
     factions: {},           // exp -> [{key, name, dot}]
     manifest: {},           // "exp/fac" -> {combat:[[..]], orders:[..], ...}  (filenames)
     text: {},               // "exp/fac" -> {combat:[[{title,general,unit,icons}]], orders:[..], events:[..]} or null
+    faq: null,              // { topics:[{key,name,dot}], qa:[{t,q,a,tag}] } from data/FAQ.json
     loading: {},            // in-flight guards
   };
 
-  var state = { expansion: null, faction: null, category: 'combat', lb: null, lbFull: false };
+  function ensureFaq() {
+    if (DATA.faq || DATA.loading.faq || !window.FS_FAQ) return;
+    DATA.loading.faq = true;
+    fetchJSON(window.FS_FAQ.src).then(function (raw) {
+      DATA.faq = window.FS_FAQ.flatten(raw);
+      render();
+    }).catch(function (e) {
+      console.error('FAQ load failed', e);
+      DATA.faq = { topics: [{ key: 'all', name: 'All Questions', dot: 'oklch(0.80 0.12 80)' }], qa: [] };
+      render();
+    });
+  }
+
+  var state = {
+    expansion: null, faction: null, category: 'combat', lb: null, lbFull: false, lbMag: false, lbZoom: 2,
+    view: 'codex',            // 'codex' | 'faq'
+    faqTopic: 'all', faqQuery: '', faqOpen: {},
+  };
   var flat = []; // flat list of currently-visible cards, for the lightbox
 
   function setState(patch) {
@@ -198,6 +216,40 @@
     return img;
   }
 
+  // Magnifier lens: a circular loupe that follows the cursor over the lightbox
+  // image, sampling the full-resolution source for close inspection.
+  // Always wired; the lens only shows while state.lbMag is on. Toggling the
+  // magnifier flips classes in place (see the toolbar button) — no re-render,
+  // so the modal never flashes/reloads.
+  function attachMagnifier(wrap, img) {
+    var LENS = 204;
+    var lens = el('div', { class: 'fs-lb-lens' });
+    wrap.appendChild(lens);
+    var ex = null, ey = null;
+    function draw() {
+      if (!state.lbMag || ex == null) { lens.style.display = 'none'; return; }
+      var r = img.getBoundingClientRect(), wr = wrap.getBoundingClientRect();
+      var x = ex - r.left, y = ey - r.top;
+      if (x < 0 || y < 0 || x > r.width || y > r.height) { lens.style.display = 'none'; return; }
+      var z = state.lbZoom;
+      lens.style.display = 'block';
+      lens.style.backgroundImage = 'url("' + (img.currentSrc || img.src) + '")';
+      lens.style.backgroundSize = (r.width * z) + 'px ' + (r.height * z) + 'px';
+      lens.style.backgroundPosition = (-(x * z - LENS / 2)) + 'px ' + (-(y * z - LENS / 2)) + 'px';
+      lens.style.left = (ex - wr.left - LENS / 2) + 'px';
+      lens.style.top = (ey - wr.top - LENS / 2) + 'px';
+    }
+    img.addEventListener('mousemove', function (ev) { ex = ev.clientX; ey = ev.clientY; draw(); });
+    img.addEventListener('mouseleave', function () { lens.style.display = 'none'; });
+    // scrollwheel adjusts the loupe magnification (no page scroll while magnifying)
+    img.addEventListener('wheel', function (ev) {
+      if (!state.lbMag) return;
+      ev.preventDefault();
+      state.lbZoom = Math.max(1.4, Math.min(6, state.lbZoom + (ev.deltaY < 0 ? 0.3 : -0.3)));
+      draw();
+    }, { passive: false });
+  }
+
   // "Unit Count" — a faction's component tally, rendered as a table card.
   function renderMaterial(materials) {
     var body;
@@ -292,11 +344,11 @@
 
   /* ---------------- lightbox ---------------- */
 
-  function openLb(idx) { setState({ lb: idx, lbFull: false }); }
-  function closeLb() { setState({ lb: null, lbFull: false }); }
+  function openLb(idx) { setState({ lb: idx, lbFull: true }); } // open zoomed by default
+  function closeLb() { setState({ lb: null }); }
   function step(d) {
     if (!flat.length || state.lb === null) return;
-    setState({ lb: (state.lb + d + flat.length) % flat.length, lbFull: false });
+    setState({ lb: (state.lb + d + flat.length) % flat.length }); // preserve zoom state
   }
 
   document.addEventListener('keydown', function (e) {
@@ -306,9 +358,145 @@
     else if (e.key === 'ArrowLeft') step(-1);
   });
 
+  /* ---------------- FAQ (Field Manual) view ---------------- */
+
+  function faqFiltered() {
+    var data = (DATA.faq && DATA.faq.qa) || [];
+    var q = (state.faqQuery || '').trim().toLowerCase();
+    return data
+      .map(function (item, i) { return { item: item, id: i }; })
+      .filter(function (e) { return state.faqTopic === 'all' || e.item.t === state.faqTopic; })
+      .filter(function (e) { return !q || (e.item.q + ' ' + e.item.a).toLowerCase().indexOf(q) >= 0; });
+  }
+
+  function faqTopicName(k) {
+    var ts = (DATA.faq && DATA.faq.topics) || [];
+    var t = findKey(ts, k);
+    return t ? t.name : '';
+  }
+
+  function renderFaqView() {
+    ensureFaq();
+    var hero = (window.FS_FAQ && window.FS_FAQ.hero) || {};
+    var FAQ = DATA.faq || { topics: [], qa: [] };
+    var ready = !!DATA.faq;
+
+    var app = el('div', { class: 'fs-app', 'data-accent': ACCENT });
+
+    // header with centered search
+    var search = el('input', {
+      class: 'fs-faq-search', type: 'text', value: state.faqQuery,
+      placeholder: 'Search questions…', spellcheck: 'false',
+      oninput: function (e) { setState({ faqQuery: e.target.value }); },
+    });
+    var header = el('header', { class: 'fs-header fs-faq-header' }, [
+      el('div', { class: 'fs-brand' }, [
+        el('div', { class: 'fs-logo' }, [el('div', { class: 'fs-logo-ring' }), el('div', { class: 'fs-logo-core' })]),
+        el('div', { class: 'fs-brand-text' }, [
+          el('span', { class: 'fs-brand-title', text: 'FORBIDDEN STARS' }),
+          el('span', { class: 'fs-brand-sub', text: 'Field Manual · FAQ' }),
+        ]),
+      ]),
+      el('div', { class: 'fs-header-spacer' }),
+      el('div', { class: 'fs-faq-searchwrap' }, [
+        el('span', { class: 'fs-faq-searchicon', html: '&#9906;' }),
+        search,
+      ]),
+      el('div', { class: 'fs-header-spacer' }),
+    ]);
+
+    // counts per topic
+    var counts = { all: FAQ.qa.length };
+    FAQ.qa.forEach(function (x) { counts[x.t] = (counts[x.t] || 0) + 1; });
+
+    var topicsNav = el('nav', { class: 'fs-nav' },
+      FAQ.topics.map(function (t) {
+        return el('button', {
+          class: 'fs-fac' + (state.faqTopic === t.key ? ' is-active' : ''),
+          onclick: (function (key) { return function () { setState({ faqTopic: key }); }; })(t.key),
+        }, [
+          el('span', { class: 'fs-fac-dot fs-faq-dot', style: 'background:' + t.dot + ';' }),
+          el('span', { class: 'fs-fac-name', text: t.name }),
+          el('span', { class: 'fs-fac-count', text: String(counts[t.key] || 0) }),
+        ]);
+      })
+    );
+    var sidebar = el('aside', { class: 'fs-sidebar fs-scroll' }, [
+      el('div', { class: 'fs-sidebar-label', text: 'Topics' }),
+      topicsNav,
+      el('div', { class: 'fs-sidebar-foot' }, [
+        el('button', { class: 'fs-faq-link fs-faq-back', html: '&larr; Back to Card Codex',
+          onclick: function () { setState({ view: 'codex' }); } }),
+        el('p', { html: 'FAN PROJECT &middot; NON&#8209;COMMERCIAL<br>Artwork &copy; Games Workshop' }),
+      ]),
+    ]);
+
+    // main: hero + accordion
+    var list = faqFiltered();
+    var sectionLabel = state.faqTopic === 'all' ? 'All Questions' : faqTopicName(state.faqTopic);
+
+    var items = list.map(function (e, i) {
+      var open = !!state.faqOpen[e.id];
+      var head = el('button', {
+        class: 'fs-faq-qbtn',
+        onclick: (function (id) { return function () {
+          var o = {}; for (var k in state.faqOpen) { if (state.faqOpen.hasOwnProperty(k)) o[k] = state.faqOpen[k]; }
+          o[id] = !o[id]; setState({ faqOpen: o });
+        }; })(e.id),
+      }, [
+        el('span', { class: 'fs-faq-num', text: String(i + 1).length < 2 ? '0' + (i + 1) : String(i + 1) }),
+        el('span', { class: 'fs-faq-q', text: e.item.q }),
+        el('span', { class: 'fs-faq-icon' + (open ? ' is-open' : ''), text: '+' }),
+      ]);
+      var children = [head];
+      if (open) {
+        children.push(el('div', { class: 'fs-faq-answer' }, [
+          el('p', { class: 'fs-faq-atext', text: e.item.a }),
+          e.item.tag ? el('span', { class: 'fs-faq-tag', text: e.item.tag }) : null,
+        ]));
+      }
+      return el('div', { class: 'fs-faq-item' + (open ? ' is-open' : '') }, children);
+    });
+
+    var contentInner;
+    if (!ready) {
+      contentInner = el('div', { class: 'fs-note', text: 'Loading…' });
+    } else if (list.length) {
+      contentInner = el('div', { class: 'fs-faq-list' }, items);
+    } else {
+      contentInner = el('div', { class: 'fs-faq-empty' }, [
+        el('div', { class: 'fs-faq-empty-glyph' }, [el('div', { class: 'ring' })]),
+        el('p', { class: 'fs-note', text: 'No questions match “' + state.faqQuery + '”. Try another term or clear the search.' }),
+      ]);
+    }
+    var body = [
+      el('div', { class: 'fs-faq-hero' }, [
+        el('span', { class: 'fs-faq-kicker', text: hero.kicker || '' }),
+        el('h1', { class: 'fs-faq-title', text: hero.title || '' }),
+        el('p', { class: 'fs-faq-blurb', text: hero.blurb || '' }),
+      ]),
+      el('div', { class: 'fs-faq-content' }, [
+        el('div', { class: 'fs-faq-sectionrow' }, [
+          el('span', { class: 'fs-faq-sectionlabel', text: sectionLabel }),
+          el('span', { class: 'fs-faq-countlabel', text: list.length + ' ' + (list.length === 1 ? 'question' : 'questions') }),
+        ]),
+        contentInner,
+      ]),
+    ];
+    var main = el('main', { class: 'fs-main fs-scroll fs-faq-main' }, body);
+
+    app.appendChild(header);
+    app.appendChild(el('div', { class: 'fs-body' }, [sidebar, main]));
+
+    var root = document.getElementById('app');
+    root.innerHTML = '';
+    root.appendChild(app);
+  }
+
   /* ---------------- render ---------------- */
 
   function render() {
+    if (state.view === 'faq') { renderFaqView(); return; }
     var acc = ACC[ACCENT] || ACC.amber;
     var cols = Math.max(2, Math.min(8, density()));
     var cat = state.category;
@@ -316,12 +504,15 @@
     var built = build();
     var groups = built.groups;
 
-    // grid geometry per category
+    // grid geometry per category. Faction Card + Maps render at the image's
+    // NATURAL aspect (no forced ratio / no crop) since their dimensions vary by
+    // expansion (e.g. The Dying Light reference sheets are landscape, not portrait).
+    var naturalCard = (cat === 'faction_card' || cat === 'map');
     var gridCols, gridJustify, cardAspect;
     if (cat === 'faction_card') {
-      gridCols = 'repeat(1, minmax(0, 860px))'; gridJustify = 'center'; cardAspect = '1688 / 2000';
+      gridCols = 'repeat(1, minmax(0, 920px))'; gridJustify = 'center'; cardAspect = '';
     } else if (cat === 'map') {
-      gridCols = 'repeat(1, minmax(0, 920px))'; gridJustify = 'center'; cardAspect = '1 / 1';
+      gridCols = 'repeat(1, minmax(0, 920px))'; gridJustify = 'center'; cardAspect = '';
     } else {
       gridCols = 'repeat(' + cols + ', minmax(0, 1fr))'; gridJustify = 'start'; cardAspect = '434 / 615';
     }
@@ -368,8 +559,15 @@
     var sidebar = el('aside', { class: 'fs-sidebar' }, [
       el('div', { class: 'fs-sidebar-label', text: 'Factions' }),
       nav,
+      el('div', { class: 'fs-sidebar-section' }, [
+        el('div', { class: 'fs-sidebar-label', text: 'Reference' }),
+        el('button', { class: 'fs-fac fs-faq-entry', onclick: function () { setState({ view: 'faq' }); } }, [
+          el('span', { class: 'fs-fac-dot fs-faq-dot', style: 'background:var(--fs-accent);' }),
+          el('span', { class: 'fs-fac-name', text: 'Field Manual / FAQ' }),
+          el('span', { class: 'fs-fac-count', html: '&rsaquo;' }),
+        ]),
+      ]),
       el('div', { class: 'fs-sidebar-foot' }, [
-        el('a', { class: 'fs-faq-link', href: 'faq_manuscript_page.html', text: 'FAQ & Rules' }),
         el('p', { html: 'FAN PROJECT &middot; NON&#8209;COMMERCIAL<br>Artwork &copy; Games Workshop' }),
       ]),
     ]);
@@ -423,9 +621,9 @@
           style: 'grid-template-columns:' + gridCols + ';justify-content:' + gridJustify + ';',
         }, group.cards.map(function (card) {
           var btn = el('button', {
-            class: 'fs-card',
+            class: 'fs-card' + (naturalCard ? ' fs-card--natural' : ''),
             title: card.label,
-            style: 'aspect-ratio:' + cardAspect + ';',
+            style: cardAspect ? ('aspect-ratio:' + cardAspect + ';') : '',
             onclick: (function (idx) { return function () { openLb(idx); }; })(card.index),
           }, [
             el('img', { src: card.src, alt: card.label, loading: 'lazy' }),
@@ -452,15 +650,20 @@
     if (state.lb !== null) {
       var c = flat[state.lb];
       if (c) {
-        var bigFormat = cat === 'faction_card' || cat === 'map';
-        var full = bigFormat && state.lbFull;
+        var full = state.lbFull;
+        var mag = state.lbMag;
+
+        var imgEl = lbImg(c);
+        var imgWrap = el('div', { class: 'fs-lb-imgwrap' + (mag ? ' mag-on' : '') }, [imgEl]);
+        attachMagnifier(imgWrap, imgEl); // always wired; gated by state.lbMag
+
         var children = [
           el('button', {
             class: 'fs-lb-nav', 'aria-label': 'Previous card', html: '&lsaquo;',
             onclick: function (e) { e.stopPropagation(); step(-1); },
           }),
           el('figure', { class: 'fs-lb-fig' + (full ? ' is-full' : ''), onclick: function (e) { e.stopPropagation(); } }, [
-            lbImg(c),
+            imgWrap,
             el('figcaption', { class: 'fs-lb-cap' }, [
               el('span', { class: 'fs-lb-label', text: c.label }),
               el('span', {
@@ -473,13 +676,33 @@
             class: 'fs-lb-nav', 'aria-label': 'Next card', html: '&rsaquo;',
             onclick: function (e) { e.stopPropagation(); step(1); },
           }),
-          bigFormat ? el('button', {
-            class: 'fs-lb-full', 'aria-label': full ? 'Exit full screen' : 'Full screen',
-            title: full ? 'Exit full screen' : 'Full screen', html: full ? '&#10532;' : '&#10530;',
-            onclick: function (e) { e.stopPropagation(); setState({ lbFull: !state.lbFull }); },
-          }) : null,
           el('button', {
-            class: 'fs-lb-close', 'aria-label': 'Close', html: '&#10005;',
+            class: 'fs-lb-tool fs-lb-mag' + (mag ? ' is-active' : ''),
+            'aria-label': 'Toggle magnifier', title: 'Toggle magnifier (scroll to zoom)',
+            html: '&#9906;',
+            onclick: function (e) {
+              e.stopPropagation();
+              state.lbMag = !state.lbMag; // toggle in place — no re-render, no flash
+              var ov = e.currentTarget.closest('.fs-lb');
+              var wrap = ov.querySelector('.fs-lb-imgwrap');
+              wrap.classList.toggle('mag-on', state.lbMag);
+              e.currentTarget.classList.toggle('is-active', state.lbMag);
+              if (!state.lbMag) { var l = wrap.querySelector('.fs-lb-lens'); if (l) l.style.display = 'none'; }
+            },
+          }),
+          el('button', {
+            class: 'fs-lb-tool fs-lb-full', 'aria-label': 'Toggle full screen', title: 'Toggle full screen',
+            html: full ? '&#10532;' : '&#10530;',
+            onclick: function (e) {
+              e.stopPropagation();
+              state.lbFull = !state.lbFull; // toggle in place — no re-render, no flash
+              var ov = e.currentTarget.closest('.fs-lb');
+              ov.querySelector('.fs-lb-fig').classList.toggle('is-full', state.lbFull);
+              e.currentTarget.innerHTML = state.lbFull ? '&#10532;' : '&#10530;';
+            },
+          }),
+          el('button', {
+            class: 'fs-lb-tool fs-lb-close', 'aria-label': 'Close', html: '&#10005;',
             onclick: function (e) { e.stopPropagation(); closeLb(); },
           }),
         ];

--- a/page/style/styles.css
+++ b/page/style/styles.css
@@ -259,6 +259,10 @@ body {
 }
 .fs-card img { width: 100%; height: 100%; object-fit: cover; display: block; }
 
+/* natural-aspect cards (faction reference sheets, maps) — never crop or force a ratio */
+.fs-card--natural { aspect-ratio: auto; }
+.fs-card--natural img { height: auto; object-fit: contain; }
+
 /* ---- unavailable state ---- */
 .fs-empty {
   flex: 1; display: flex; flex-direction: column; align-items: center;
@@ -308,7 +312,7 @@ body {
   animation: fspop .2s ease;
 }
 .fs-lb-fig img {
-  max-height: 80vh; max-width: min(640px, 80vw); border-radius: 14px;
+  max-height: 90vh; max-width: min(1100px, 92vw); border-radius: 14px;
   border: 1px solid #38332c; box-shadow: 0 40px 90px -25px #000; display: block;
 }
 .fs-lb-cap { display: flex; flex-direction: column; align-items: center; gap: 6px; }
@@ -317,20 +321,121 @@ body {
   font-family: 'IBM Plex Mono', monospace; font-size: 10.5px; letter-spacing: 0.16em;
   text-transform: uppercase; color: var(--fs-accent);
 }
-.fs-lb-close, .fs-lb-full {
+.fs-lb-tool {
   position: absolute; top: 22px; width: 38px; height: 38px;
   border-radius: 50%; border: 1px solid #38332c; background: rgba(30, 28, 26, .85);
   color: #b3ada3; font-size: 15px; line-height: 1; cursor: pointer; display: flex;
-  align-items: center; justify-content: center; transition: all .15s;
+  align-items: center; justify-content: center; transition: all .15s; z-index: 3;
 }
 .fs-lb-close { right: 24px; }
 .fs-lb-full { right: 70px; font-size: 16px; }
-.fs-lb-close:hover, .fs-lb-full:hover { border-color: var(--fs-accent); color: #f3efe8; }
+.fs-lb-mag { right: 116px; font-size: 15px; }
+.fs-lb-tool:hover { border-color: var(--fs-accent); color: #f3efe8; }
+.fs-lb-tool.is-active { border-color: var(--fs-accent); color: var(--fs-accent-fg); background: var(--fs-accent); }
 
 /* full-screen mode: image fills the viewport vertically, caption hidden */
 .fs-lb-fig.is-full { gap: 0; }
 .fs-lb-fig.is-full img { max-height: 96vh; max-width: 94vw; border-radius: 8px; }
 .fs-lb-fig.is-full .fs-lb-cap { display: none; }
+
+/* magnifier loupe */
+.fs-lb-imgwrap { position: relative; display: inline-block; line-height: 0; }
+.fs-lb-imgwrap.mag-on { cursor: crosshair; }
+.fs-lb-lens {
+  position: absolute; display: none; width: 204px; height: 204px; border-radius: 50%;
+  border: 2px solid var(--fs-accent); background-color: #0c0b0a; background-repeat: no-repeat;
+  box-shadow: 0 6px 26px rgba(0, 0, 0, .7); pointer-events: none; z-index: 5;
+}
+
+/* ---- sidebar Reference section + FAQ entry ---- */
+.fs-sidebar-section { margin-top: 22px; }
+.fs-faq-entry { margin-top: 2px; }
+.fs-faq-dot { border-radius: 2px; transform: rotate(45deg); }
+.fs-faq-entry .fs-fac-count { font-size: 14px; color: #6f6a61; }
+
+/* ---- FAQ view ---- */
+.fs-header-spacer { flex: 1; }
+.fs-faq-searchwrap {
+  position: relative; display: flex; align-items: center;
+  width: 280px; max-width: 42vw; flex-shrink: 0;
+}
+.fs-faq-searchicon {
+  position: absolute; left: 13px; font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px; color: #6f6a61; pointer-events: none;
+}
+.fs-faq-search {
+  width: 100%; appearance: none; font-family: inherit; font-size: 13px; color: #ece8e1;
+  background: #1d1b18; border: 1px solid #2c2925; border-radius: 9px;
+  padding: 9px 13px 9px 32px; outline: none; transition: border-color .15s;
+}
+.fs-faq-search:focus { border-color: var(--fs-accent); }
+
+.fs-faq-back {
+  display: inline-flex; align-items: center; gap: 7px; appearance: none;
+  background: none; border: none; cursor: pointer; padding: 0; margin: 0 0 12px;
+}
+
+.fs-faq-main { display: block; min-height: 0; overflow-y: auto; }
+.fs-faq-header .fs-faq-searchwrap { width: 360px; max-width: 46vw; }
+.fs-faq-hero {
+  padding: 34px 40px 22px; border-bottom: 1px solid #221f1a;
+  background: linear-gradient(180deg, #16140f, #121110);
+}
+.fs-faq-kicker {
+  font-family: 'IBM Plex Mono', monospace; font-size: 10px; letter-spacing: 0.24em;
+  text-transform: uppercase; color: var(--fs-accent);
+}
+.fs-faq-title {
+  font-size: 27px; font-weight: 700; margin: 10px 0 8px; letter-spacing: -0.01em; color: #f3efe8;
+}
+.fs-faq-blurb { font-size: 13.5px; line-height: 1.65; color: #9a948a; margin: 0; max-width: 620px; }
+
+.fs-faq-content { padding: 22px 40px 60px; max-width: 840px; }
+.fs-faq-sectionrow {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 16px;
+}
+.fs-faq-sectionlabel {
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px; letter-spacing: 0.18em;
+  text-transform: uppercase; color: #bdb7ac;
+}
+.fs-faq-countlabel {
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #857f74;
+  letter-spacing: 0.08em; white-space: nowrap;
+}
+.fs-faq-list { display: flex; flex-direction: column; gap: 10px; }
+.fs-faq-item {
+  border: 1px solid #2c2925; background: #1a1815; border-radius: 13px; overflow: hidden;
+  transition: border-color .18s ease, background .18s ease;
+}
+.fs-faq-item.is-open { border-color: var(--fs-accent); background: #1b1916; }
+.fs-faq-qbtn {
+  appearance: none; cursor: pointer; width: 100%; text-align: left; display: flex;
+  align-items: flex-start; gap: 15px; background: transparent; border: none;
+  padding: 17px 19px; font-family: inherit; color: #f3efe8;
+}
+.fs-faq-qbtn:hover { color: #fff; }
+.fs-faq-num {
+  font-family: 'IBM Plex Mono', monospace; font-size: 10.5px; font-weight: 500;
+  letter-spacing: 0.05em; color: var(--fs-accent); padding-top: 3px; flex-shrink: 0; width: 30px;
+}
+.fs-faq-q { flex: 1; font-size: 14.5px; font-weight: 600; line-height: 1.45; }
+.fs-faq-icon {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%; border: 1px solid #38332c;
+  display: flex; align-items: center; justify-content: center; font-size: 15px; line-height: 1;
+  color: #9a948a; margin-top: 1px; transition: transform .2s ease, border-color .15s;
+}
+.fs-faq-icon.is-open { transform: rotate(45deg); border-color: var(--fs-accent); color: var(--fs-accent); }
+.fs-faq-answer { padding: 0 19px 19px 64px; animation: fsexpand .2s ease; }
+.fs-faq-atext { font-size: 13.5px; line-height: 1.72; color: #c4bfb5; margin: 0; }
+.fs-faq-tag {
+  display: inline-block; margin-top: 13px; font-family: 'IBM Plex Mono', monospace;
+  font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--fs-accent);
+  border: 1px solid #34302a; border-radius: 6px; padding: 4px 9px;
+}
+.fs-faq-empty { display: flex; flex-direction: column; align-items: center; gap: 14px; padding: 60px 20px; text-align: center; }
+.fs-faq-empty-glyph { position: relative; width: 44px; height: 44px; opacity: 0.8; }
+.fs-faq-empty-glyph .ring { position: absolute; inset: 3px; transform: rotate(45deg); border: 1.5px solid #3a3631; border-radius: 5px; }
+@keyframes fsexpand { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
 
 /* ---- responsive ---- */
 @media (max-width: 900px) {


### PR DESCRIPTION
Follow-up to the merged codex redesign. Built on current `main`.

## Zoom / modal
- Lightbox opens **zoomed (full)** by default; full-screen toggle on every card.
- Raised image caps so high-res scans display large — native sizes range **434px–3118px**; no upscaling so detail stays crisp.
- **Magnifier loupe** (toolbar toggle): circular loupe follows the cursor sampling the full-resolution source; **scroll wheel adjusts magnification**.
- Toggling magnifier / full-screen updates **in place** — no re-render, no modal flash.

## Faction Card & Maps
- Render at the image's **natural aspect** (no forced ratio, no crop) — fixes The Dying Light reference sheets (landscape 3118×1878) overflowing the portrait box.

## FAQ (Field Manual)
- Moved into the app as a first-class view reachable from the sidebar, styled to match the **Forbidden Stars FAQ** design (search header, topic sidebar, accordion).
- Content from the real **`data/FAQ.json`**: topics = Base Game / Galaxy in Flames / Symphony of War, ~144 questions.
- **Centered search** in the navbar; main column **scrolls** with many answers open.

Verified in-browser: all card categories, lightbox default-zoom + full-screen + magnifier (incl. wheel zoom), faction-card/map natural aspect, FAQ data/scroll/search — no console errors beyond expected optional-`text.json` 404 probes.