### PR TITLE
FAQ grouping, magnifier upgrades, modal tooltips & polish

### DIFF
--- a/page/script/faq.js
+++ b/page/script/faq.js
@@ -23,28 +23,42 @@
     },
     dots: DOTS,
 
-    // raw FAQ.json -> { topics:[{key,name,dot}], qa:[{t,q,a,tag}] }
+    // raw FAQ.json -> hierarchical model:
+    //   navTopics: [{key,name,kind:'all'|'cat'|'sub',parent?,dot?}]   (sidebar)
+    //   cats:      [{key,name,dot, subs:[{key,name, factions:[{faction,picture,items:[{id,q,a}]}]}]}]
+    //   count:     { <topicKey>: n, all: n }
     flatten: function (raw) {
-      var topics = [{ key: 'all', name: 'All Questions', dot: DOTS[0] }];
-      var qa = [];
+      var navTopics = [{ key: 'all', name: 'All Questions', kind: 'all', dot: DOTS[0] }];
+      var cats = [];
+      var count = { all: 0 };
+      var uid = 0;
       (raw || []).forEach(function (cat, ci) {
-        var key = 'c' + ci;
-        topics.push({ key: key, name: cat.Category || ('Section ' + (ci + 1)), dot: DOTS[(ci + 1) % DOTS.length] });
-        (cat.items || []).forEach(function (sub) {
+        var ckey = 'c' + ci;
+        var catObj = { key: ckey, name: cat.Category || ('Section ' + (ci + 1)), dot: DOTS[(ci + 1) % DOTS.length], subs: [] };
+        navTopics.push({ key: ckey, name: catObj.name, kind: 'cat', dot: catObj.dot });
+        count[ckey] = 0;
+        (cat.items || []).forEach(function (sub, si) {
+          var skey = ckey + '_s' + si;
+          var subObj = { key: skey, name: sub.SubCategory || ('Group ' + (si + 1)), factions: [] };
+          var subCount = 0;
           (sub.items || []).forEach(function (fac) {
+            var facObj = { faction: fac.Faction || '', picture: fac.picture || '', items: [] };
             (fac.items || []).forEach(function (it) {
               if (!it || !it.Phrase) return;
-              qa.push({
-                t: key,
-                q: it.Phrase,
-                a: it.Main || '',
-                tag: sub.SubCategory || fac.Faction || null,
-              });
+              facObj.items.push({ id: uid++, q: it.Phrase, a: it.Main || '' });
+              subCount++; count[ckey]++; count.all++;
             });
+            if (facObj.items.length) subObj.factions.push(facObj);
           });
+          if (subObj.factions.length) {
+            count[skey] = subCount;
+            navTopics.push({ key: skey, name: subObj.name, kind: 'sub', parent: ckey });
+            catObj.subs.push(subObj);
+          }
         });
+        cats.push(catObj);
       });
-      return { topics: topics, qa: qa };
+      return { navTopics: navTopics, cats: cats, count: count };
     },
   };
 })();

--- a/page/script/script.js
+++ b/page/script/script.js
@@ -713,7 +713,7 @@
           el('button', {
             class: 'fs-lb-tool fs-lb-mag' + (mag ? ' is-active' : ''),
             'aria-label': 'Toggle magnifier',
-            title: 'Magnifier — scroll to zoom, Shift-scroll to resize the loupe',
+            'data-tip': 'Magnifier · scroll: zoom · Shift-scroll: resize',
             html: '&#9906;',
             onclick: function (e) {
               e.stopPropagation();
@@ -728,7 +728,8 @@
             },
           }),
           el('button', {
-            class: 'fs-lb-tool fs-lb-full', 'aria-label': 'Toggle full screen', title: 'Toggle full screen',
+            class: 'fs-lb-tool fs-lb-full', 'aria-label': 'Toggle full screen',
+            'data-tip': full ? 'Fit to window' : 'Fill screen',
             html: full ? '&#10532;' : '&#10530;',
             onclick: function (e) {
               e.stopPropagation();
@@ -736,10 +737,11 @@
               var ov = e.currentTarget.closest('.fs-lb');
               ov.querySelector('.fs-lb-fig').classList.toggle('is-full', state.lbFull);
               e.currentTarget.innerHTML = state.lbFull ? '&#10532;' : '&#10530;';
+              e.currentTarget.setAttribute('data-tip', state.lbFull ? 'Fit to window' : 'Fill screen');
             },
           }),
           el('button', {
-            class: 'fs-lb-tool fs-lb-close', 'aria-label': 'Close', html: '&#10005;',
+            class: 'fs-lb-tool fs-lb-close', 'aria-label': 'Close', 'data-tip': 'Close (Esc)', html: '&#10005;',
             onclick: function (e) { e.stopPropagation(); closeLb(); },
           }),
         ];

--- a/page/script/script.js
+++ b/page/script/script.js
@@ -457,9 +457,9 @@
           shown += its.length;
           facNodes.push(el('div', { class: 'fs-faq-facgroup' }, [
             el('div', { class: 'fs-faq-fachead' }, [
-              fac.picture ? el('img', { class: 'fs-faq-facicon', src: fac.picture, alt: '', loading: 'lazy' }) : null,
               el('span', { class: 'fs-faq-facname', text: fac.faction || sub.name }),
               el('span', { class: 'fs-faq-faccount', text: String(its.length) }),
+              fac.picture ? el('img', { class: 'fs-faq-facicon', src: fac.picture, alt: '', loading: 'lazy' }) : null,
             ]),
             el('div', { class: 'fs-faq-list' }, its.map(faqItemNode)),
           ]));

--- a/page/script/script.js
+++ b/page/script/script.js
@@ -79,7 +79,7 @@
   }
 
   var state = {
-    expansion: null, faction: null, category: 'combat', lb: null, lbFull: false, lbMag: false, lbZoom: 2,
+    expansion: null, faction: null, category: 'combat', lb: null, lbFull: false, lbMag: false, lbZoom: 2, lbLensSize: 204,
     view: 'codex',            // 'codex' | 'faq'
     faqTopic: 'all', faqQuery: '', faqOpen: {},
   };
@@ -222,11 +222,12 @@
   // magnifier flips classes in place (see the toolbar button) — no re-render,
   // so the modal never flashes/reloads.
   function attachMagnifier(wrap, img) {
-    var LENS = 204;
     var lens = el('div', { class: 'fs-lb-lens' });
     wrap.appendChild(lens);
     var ex = null, ey = null;
     function draw() {
+      var L = state.lbLensSize;
+      lens.style.width = L + 'px'; lens.style.height = L + 'px';
       if (!state.lbMag || ex == null) { lens.style.display = 'none'; return; }
       var r = img.getBoundingClientRect(), wr = wrap.getBoundingClientRect();
       var x = ex - r.left, y = ey - r.top;
@@ -235,17 +236,23 @@
       lens.style.display = 'block';
       lens.style.backgroundImage = 'url("' + (img.currentSrc || img.src) + '")';
       lens.style.backgroundSize = (r.width * z) + 'px ' + (r.height * z) + 'px';
-      lens.style.backgroundPosition = (-(x * z - LENS / 2)) + 'px ' + (-(y * z - LENS / 2)) + 'px';
-      lens.style.left = (ex - wr.left - LENS / 2) + 'px';
-      lens.style.top = (ey - wr.top - LENS / 2) + 'px';
+      lens.style.backgroundPosition = (-(x * z - L / 2)) + 'px ' + (-(y * z - L / 2)) + 'px';
+      lens.style.left = (ex - wr.left - L / 2) + 'px';
+      lens.style.top = (ey - wr.top - L / 2) + 'px';
     }
     img.addEventListener('mousemove', function (ev) { ex = ev.clientX; ey = ev.clientY; draw(); });
     img.addEventListener('mouseleave', function () { lens.style.display = 'none'; });
-    // scrollwheel adjusts the loupe magnification (no page scroll while magnifying)
+    // scroll = change magnification; Shift+scroll = resize the loupe circle
     img.addEventListener('wheel', function (ev) {
       if (!state.lbMag) return;
       ev.preventDefault();
-      state.lbZoom = Math.max(1.4, Math.min(6, state.lbZoom + (ev.deltaY < 0 ? 0.3 : -0.3)));
+      var delta = ev.deltaY !== 0 ? ev.deltaY : ev.deltaX; // shift may map wheel to X
+      var up = delta < 0;
+      if (ev.shiftKey) {
+        state.lbLensSize = Math.max(120, Math.min(520, state.lbLensSize + (up ? 20 : -20)));
+      } else {
+        state.lbZoom = Math.max(1.4, Math.min(6, state.lbZoom + (up ? 0.3 : -0.3)));
+      }
       draw();
     }, { passive: false });
   }
@@ -700,9 +707,13 @@
             class: 'fs-lb-nav', 'aria-label': 'Next card', html: '&rsaquo;',
             onclick: function (e) { e.stopPropagation(); step(1); },
           }),
+          el('div', { class: 'fs-lb-maghint' + (mag ? '' : ' hidden') }, [
+            'Scroll to zoom · Shift-scroll to resize loupe',
+          ]),
           el('button', {
             class: 'fs-lb-tool fs-lb-mag' + (mag ? ' is-active' : ''),
-            'aria-label': 'Toggle magnifier', title: 'Toggle magnifier (scroll to zoom)',
+            'aria-label': 'Toggle magnifier',
+            title: 'Magnifier — scroll to zoom, Shift-scroll to resize the loupe',
             html: '&#9906;',
             onclick: function (e) {
               e.stopPropagation();
@@ -711,6 +722,8 @@
               var wrap = ov.querySelector('.fs-lb-imgwrap');
               wrap.classList.toggle('mag-on', state.lbMag);
               e.currentTarget.classList.toggle('is-active', state.lbMag);
+              var hint = ov.querySelector('.fs-lb-maghint');
+              if (hint) hint.classList.toggle('hidden', !state.lbMag);
               if (!state.lbMag) { var l = wrap.querySelector('.fs-lb-lens'); if (l) l.style.display = 'none'; }
             },
           }),

--- a/page/script/script.js
+++ b/page/script/script.js
@@ -370,7 +370,7 @@
   // so toggling is a local class flip (no re-render, no scroll jump).
   function faqItemNode(it) {
     var open = !!state.faqOpen[it.id];
-    var icon = el('span', { class: 'fs-faq-icon' + (open ? ' is-open' : ''), text: '+' });
+    var icon = el('span', { class: 'fs-faq-icon' + (open ? ' is-open' : '') });
     var head = el('button', { class: 'fs-faq-qbtn', onclick: function (e) {
       var o = !state.faqOpen[it.id];
       state.faqOpen[it.id] = o;
@@ -465,9 +465,10 @@
           ]));
         });
         if (facNodes.length) {
-          subNodes.push(el('div', { class: 'fs-faq-subsection' }, [
-            el('div', { class: 'fs-faq-sublabel', text: sub.name }),
-          ].concat(facNodes)));
+          // skip the sub-heading when this exact sub is the selected topic — the
+          // section row already names it (avoids a duplicate label)
+          var subKids = (topic === sub.key) ? [] : [el('div', { class: 'fs-faq-sublabel', text: sub.name })];
+          subNodes.push(el('div', { class: 'fs-faq-subsection' }, subKids.concat(facNodes)));
         }
       });
       if (subNodes.length) {

--- a/page/script/script.js
+++ b/page/script/script.js
@@ -402,7 +402,7 @@
       oninput: function (e) { setState({ faqQuery: e.target.value }); },
     });
     var header = el('header', { class: 'fs-header fs-faq-header' }, [
-      el('div', { class: 'fs-brand' }, [
+      el('div', { class: 'fs-brand fs-brand-link', title: 'Home', onclick: goHome }, [
         el('div', { class: 'fs-logo' }, [el('div', { class: 'fs-logo-ring' }), el('div', { class: 'fs-logo-core' })]),
         el('div', { class: 'fs-brand-text' }, [
           el('span', { class: 'fs-brand-title', text: 'FORBIDDEN STARS' }),
@@ -553,7 +553,7 @@
       })
     );
     var header = el('header', { class: 'fs-header' }, [
-      el('div', { class: 'fs-brand' }, [
+      el('div', { class: 'fs-brand fs-brand-link', title: 'Home', onclick: goHome }, [
         el('div', { class: 'fs-logo' }, [
           el('div', { class: 'fs-logo-ring' }),
           el('div', { class: 'fs-logo-core' }),
@@ -737,6 +737,15 @@
     var root = document.getElementById('app');
     root.innerHTML = '';
     root.appendChild(app);
+  }
+
+  // brand/logo click → back to the default codex view (first expansion/faction, Combat)
+  function goHome() {
+    var first = DATA.expansions[0] ? DATA.expansions[0].key : state.expansion;
+    ensureFactions(first);
+    var list = DATA.factions[first];
+    var fac = list && list[0] ? list[0].key : null;
+    setState({ view: 'codex', expansion: first, faction: fac, category: 'combat', lb: null });
   }
 
   function selectExpansion(key) {

--- a/page/script/script.js
+++ b/page/script/script.js
@@ -360,26 +360,38 @@
 
   /* ---------------- FAQ (Field Manual) view ---------------- */
 
-  function faqFiltered() {
-    var data = (DATA.faq && DATA.faq.qa) || [];
-    var q = (state.faqQuery || '').trim().toLowerCase();
-    return data
-      .map(function (item, i) { return { item: item, id: i }; })
-      .filter(function (e) { return state.faqTopic === 'all' || e.item.t === state.faqTopic; })
-      .filter(function (e) { return !q || (e.item.q + ' ' + e.item.a).toLowerCase().indexOf(q) >= 0; });
+  function faqTopicName(k) {
+    var ts = (DATA.faq && DATA.faq.navTopics) || [];
+    var t = findKey(ts, k);
+    return t ? t.name : 'All Questions';
   }
 
-  function faqTopicName(k) {
-    var ts = (DATA.faq && DATA.faq.topics) || [];
-    var t = findKey(ts, k);
-    return t ? t.name : '';
+  // one accordion row — the answer is always in the DOM and shown/hidden by CSS,
+  // so toggling is a local class flip (no re-render, no scroll jump).
+  function faqItemNode(it) {
+    var open = !!state.faqOpen[it.id];
+    var icon = el('span', { class: 'fs-faq-icon' + (open ? ' is-open' : ''), text: '+' });
+    var head = el('button', { class: 'fs-faq-qbtn', onclick: function (e) {
+      var o = !state.faqOpen[it.id];
+      state.faqOpen[it.id] = o;
+      e.currentTarget.parentNode.classList.toggle('is-open', o);
+      icon.classList.toggle('is-open', o);
+    } }, [
+      el('span', { class: 'fs-faq-q', text: it.q }),
+      icon,
+    ]);
+    var answer = el('div', { class: 'fs-faq-answer' }, [el('p', { class: 'fs-faq-atext', text: it.a })]);
+    return el('div', { class: 'fs-faq-item' + (open ? ' is-open' : '') }, [head, answer]);
   }
 
   function renderFaqView() {
     ensureFaq();
     var hero = (window.FS_FAQ && window.FS_FAQ.hero) || {};
-    var FAQ = DATA.faq || { topics: [], qa: [] };
+    var FAQ = DATA.faq || { navTopics: [], cats: [], count: {} };
     var ready = !!DATA.faq;
+    var topic = state.faqTopic;
+    var q = (state.faqQuery || '').trim().toLowerCase();
+    var matches = function (it) { return !q || (it.q + ' ' + it.a).toLowerCase().indexOf(q) >= 0; };
 
     var app = el('div', { class: 'fs-app', 'data-accent': ACCENT });
 
@@ -405,20 +417,17 @@
       el('div', { class: 'fs-header-spacer' }),
     ]);
 
-    // counts per topic
-    var counts = { all: FAQ.qa.length };
-    FAQ.qa.forEach(function (x) { counts[x.t] = (counts[x.t] || 0) + 1; });
-
+    // sidebar: categories with their sub-categories nested
     var topicsNav = el('nav', { class: 'fs-nav' },
-      FAQ.topics.map(function (t) {
-        return el('button', {
-          class: 'fs-fac' + (state.faqTopic === t.key ? ' is-active' : ''),
-          onclick: (function (key) { return function () { setState({ faqTopic: key }); }; })(t.key),
-        }, [
-          el('span', { class: 'fs-fac-dot fs-faq-dot', style: 'background:' + t.dot + ';' }),
-          el('span', { class: 'fs-fac-name', text: t.name }),
-          el('span', { class: 'fs-fac-count', text: String(counts[t.key] || 0) }),
-        ]);
+      FAQ.navTopics.map(function (t) {
+        var active = topic === t.key;
+        var cls = (t.kind === 'sub') ? ('fs-faq-subnav' + (active ? ' is-active' : ''))
+          : ('fs-fac' + (t.kind === 'cat' ? ' fs-faq-catnav' : '') + (active ? ' is-active' : ''));
+        var kids = [];
+        if (t.kind !== 'sub') kids.push(el('span', { class: 'fs-fac-dot fs-faq-dot', style: 'background:' + (t.dot || 'var(--fs-accent)') + ';' }));
+        kids.push(el('span', { class: 'fs-fac-name', text: t.name }));
+        kids.push(el('span', { class: 'fs-fac-count', text: String(FAQ.count[t.key] || 0) }));
+        return el('button', { class: cls, onclick: (function (key) { return function () { setState({ faqTopic: key }); }; })(t.key) }, kids);
       })
     );
     var sidebar = el('aside', { class: 'fs-sidebar fs-scroll' }, [
@@ -431,44 +440,58 @@
       ]),
     ]);
 
-    // main: hero + accordion
-    var list = faqFiltered();
-    var sectionLabel = state.faqTopic === 'all' ? 'All Questions' : faqTopicName(state.faqTopic);
-
-    var items = list.map(function (e, i) {
-      var open = !!state.faqOpen[e.id];
-      var head = el('button', {
-        class: 'fs-faq-qbtn',
-        onclick: (function (id) { return function () {
-          var o = {}; for (var k in state.faqOpen) { if (state.faqOpen.hasOwnProperty(k)) o[k] = state.faqOpen[k]; }
-          o[id] = !o[id]; setState({ faqOpen: o });
-        }; })(e.id),
-      }, [
-        el('span', { class: 'fs-faq-num', text: String(i + 1).length < 2 ? '0' + (i + 1) : String(i + 1) }),
-        el('span', { class: 'fs-faq-q', text: e.item.q }),
-        el('span', { class: 'fs-faq-icon' + (open ? ' is-open' : ''), text: '+' }),
-      ]);
-      var children = [head];
-      if (open) {
-        children.push(el('div', { class: 'fs-faq-answer' }, [
-          el('p', { class: 'fs-faq-atext', text: e.item.a }),
-          e.item.tag ? el('span', { class: 'fs-faq-tag', text: e.item.tag }) : null,
+    // main: hero + grouped content (Category › SubCategory › Faction › questions)
+    var showAll = topic === 'all';
+    var sections = [];
+    var shown = 0;
+    FAQ.cats.forEach(function (cat) {
+      var catSelected = showAll || topic === cat.key || topic.indexOf(cat.key + '_') === 0;
+      if (!catSelected) return;
+      var subNodes = [];
+      cat.subs.forEach(function (sub) {
+        if (!showAll && topic !== cat.key && topic !== sub.key) return;
+        var facNodes = [];
+        sub.factions.forEach(function (fac) {
+          var its = fac.items.filter(matches);
+          if (!its.length) return;
+          shown += its.length;
+          facNodes.push(el('div', { class: 'fs-faq-facgroup' }, [
+            el('div', { class: 'fs-faq-fachead' }, [
+              fac.picture ? el('img', { class: 'fs-faq-facicon', src: fac.picture, alt: '', loading: 'lazy' }) : null,
+              el('span', { class: 'fs-faq-facname', text: fac.faction || sub.name }),
+              el('span', { class: 'fs-faq-faccount', text: String(its.length) }),
+            ]),
+            el('div', { class: 'fs-faq-list' }, its.map(faqItemNode)),
+          ]));
+        });
+        if (facNodes.length) {
+          subNodes.push(el('div', { class: 'fs-faq-subsection' }, [
+            el('div', { class: 'fs-faq-sublabel', text: sub.name }),
+          ].concat(facNodes)));
+        }
+      });
+      if (subNodes.length) {
+        var catChildren = [];
+        if (showAll) catChildren.push(el('h2', { class: 'fs-faq-cathead' }, [
+          el('span', { class: 'fs-faq-catdot', style: 'background:' + cat.dot + ';' }),
+          cat.name,
         ]));
+        sections.push(el('div', { class: 'fs-faq-catblock' }, catChildren.concat(subNodes)));
       }
-      return el('div', { class: 'fs-faq-item' + (open ? ' is-open' : '') }, children);
     });
 
     var contentInner;
     if (!ready) {
       contentInner = el('div', { class: 'fs-note', text: 'Loading…' });
-    } else if (list.length) {
-      contentInner = el('div', { class: 'fs-faq-list' }, items);
+    } else if (shown) {
+      contentInner = el('div', { class: 'fs-faq-sections' }, sections);
     } else {
       contentInner = el('div', { class: 'fs-faq-empty' }, [
         el('div', { class: 'fs-faq-empty-glyph' }, [el('div', { class: 'ring' })]),
-        el('p', { class: 'fs-note', text: 'No questions match “' + state.faqQuery + '”. Try another term or clear the search.' }),
+        el('p', { class: 'fs-note', text: q ? ('No questions match “' + state.faqQuery + '”. Try another term or clear the search.') : 'No questions in this section.' }),
       ]);
     }
+
     var body = [
       el('div', { class: 'fs-faq-hero' }, [
         el('span', { class: 'fs-faq-kicker', text: hero.kicker || '' }),
@@ -477,8 +500,8 @@
       ]),
       el('div', { class: 'fs-faq-content' }, [
         el('div', { class: 'fs-faq-sectionrow' }, [
-          el('span', { class: 'fs-faq-sectionlabel', text: sectionLabel }),
-          el('span', { class: 'fs-faq-countlabel', text: list.length + ' ' + (list.length === 1 ? 'question' : 'questions') }),
+          el('span', { class: 'fs-faq-sectionlabel', text: faqTopicName(topic) }),
+          el('span', { class: 'fs-faq-countlabel', text: shown + ' ' + (shown === 1 ? 'question' : 'questions') }),
         ]),
         contentInner,
       ]),

--- a/page/style/styles.css
+++ b/page/style/styles.css
@@ -334,9 +334,21 @@ body {
 .fs-lb-tool:hover { border-color: var(--fs-accent); color: #f3efe8; }
 .fs-lb-tool.is-active { border-color: var(--fs-accent); color: var(--fs-accent-fg); background: var(--fs-accent); }
 
-/* full-screen mode: image fills the viewport vertically, caption hidden */
+/* hover tooltip for the top-right tool buttons */
+.fs-lb-tool[data-tip]::after {
+  content: attr(data-tip); position: absolute; top: calc(100% + 9px); right: 0;
+  background: rgba(20, 18, 16, .96); border: 1px solid #38332c; color: #e6e1d8;
+  font-family: 'IBM Plex Mono', monospace; font-size: 10.5px; letter-spacing: 0.04em;
+  white-space: nowrap; padding: 6px 10px; border-radius: 7px; box-shadow: 0 6px 18px rgba(0, 0, 0, .5);
+  opacity: 0; transform: translateY(-3px); pointer-events: none;
+  transition: opacity .12s ease, transform .12s ease; z-index: 10;
+}
+.fs-lb-tool[data-tip]:hover::after { opacity: 1; transform: translateY(0); }
+
+/* full-screen mode: image actually fills the viewport vertically (upscaling
+   small scans), width capped so landscape sheets don't overflow; caption hidden */
 .fs-lb-fig.is-full { gap: 0; }
-.fs-lb-fig.is-full img { max-height: 96vh; max-width: 94vw; border-radius: 8px; }
+.fs-lb-fig.is-full img { height: 96vh; width: auto; max-width: 94vw; max-height: 96vh; border-radius: 8px; }
 .fs-lb-fig.is-full .fs-lb-cap { display: none; }
 
 /* magnifier loupe */

--- a/page/style/styles.css
+++ b/page/style/styles.css
@@ -461,10 +461,10 @@ body {
   padding-bottom: 8px; margin-top: 8px;
 }
 .fs-faq-facgroup { display: flex; flex-direction: column; gap: 8px; }
-.fs-faq-fachead { display: flex; align-items: center; gap: 10px; padding: 4px 2px 2px; }
-.fs-faq-facicon { width: 24px; height: 24px; object-fit: contain; flex-shrink: 0; }
+.fs-faq-fachead { display: flex; align-items: center; gap: 12px; padding: 4px 2px 2px; }
 .fs-faq-facname { font-size: 13px; font-weight: 600; color: #d8d2c8; letter-spacing: 0.01em; flex: 1; }
 .fs-faq-faccount { font-family: 'IBM Plex Mono', monospace; font-size: 10px; color: #6f6a61; }
+.fs-faq-facicon { width: 52px; height: 52px; object-fit: contain; flex-shrink: 0; margin-left: 4px; }
 .fs-faq-tag {
   display: inline-block; margin-top: 13px; font-family: 'IBM Plex Mono', monospace;
   font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--fs-accent);

--- a/page/style/styles.css
+++ b/page/style/styles.css
@@ -81,6 +81,7 @@ body {
   z-index: 10;
 }
 .fs-brand { display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
+.fs-brand-link { cursor: pointer; }
 .fs-logo { position: relative; width: 24px; height: 24px; flex-shrink: 0; }
 .fs-logo-ring {
   position: absolute; inset: 2px; transform: rotate(45deg);

--- a/page/style/styles.css
+++ b/page/style/styles.css
@@ -471,7 +471,7 @@ body {
 .fs-faq-fachead { display: flex; align-items: center; gap: 12px; padding: 4px 2px 2px; }
 .fs-faq-facname { font-size: 13px; font-weight: 600; color: #d8d2c8; letter-spacing: 0.01em; flex: 1; }
 .fs-faq-faccount { font-family: 'IBM Plex Mono', monospace; font-size: 10px; color: #6f6a61; }
-.fs-faq-facicon { width: 52px; height: 52px; object-fit: contain; flex-shrink: 0; margin-left: 4px; }
+.fs-faq-facicon { width: 104px; height: 104px; object-fit: contain; flex-shrink: 0; margin-left: 4px; }
 .fs-faq-tag {
   display: inline-block; margin-top: 13px; font-family: 'IBM Plex Mono', monospace;
   font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--fs-accent);

--- a/page/style/styles.css
+++ b/page/style/styles.css
@@ -420,10 +420,16 @@ body {
 }
 .fs-faq-q { flex: 1; font-size: 14.5px; font-weight: 600; line-height: 1.45; }
 .fs-faq-icon {
-  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%; border: 1px solid #38332c;
-  display: flex; align-items: center; justify-content: center; font-size: 15px; line-height: 1;
-  color: #9a948a; margin-top: 1px; transition: transform .2s ease, border-color .15s;
+  position: relative; flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  border: 1px solid #38332c; color: #9a948a;
+  transition: transform .2s ease, border-color .15s, color .15s;
 }
+/* plus drawn as two centered bars so it stays perfectly centred and rotates to × */
+.fs-faq-icon::before, .fs-faq-icon::after {
+  content: ''; position: absolute; left: 50%; top: 50%; background: currentColor; border-radius: 1px;
+}
+.fs-faq-icon::before { width: 9px; height: 1.6px; transform: translate(-50%, -50%); }
+.fs-faq-icon::after { width: 1.6px; height: 9px; transform: translate(-50%, -50%); }
 .fs-faq-icon.is-open { transform: rotate(45deg); border-color: var(--fs-accent); color: var(--fs-accent); }
 .fs-faq-answer { display: none; padding: 0 19px 18px; }
 .fs-faq-item.is-open .fs-faq-answer { display: block; animation: fsexpand .2s ease; }

--- a/page/style/styles.css
+++ b/page/style/styles.css
@@ -348,6 +348,15 @@ body {
   box-shadow: 0 6px 26px rgba(0, 0, 0, .7); pointer-events: none; z-index: 5;
 }
 
+/* magnifier control hint */
+.fs-lb-maghint {
+  position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%);
+  background: rgba(20, 18, 16, .92); border: 1px solid #38332c; color: #c4bdb1;
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px; letter-spacing: 0.06em;
+  padding: 7px 14px; border-radius: 20px; z-index: 6; pointer-events: none; white-space: nowrap;
+}
+.fs-lb-maghint.hidden { display: none; }
+
 /* ---- sidebar Reference section + FAQ entry ---- */
 .fs-sidebar-section { margin-top: 22px; }
 .fs-faq-entry { margin-top: 2px; }

--- a/page/style/styles.css
+++ b/page/style/styles.css
@@ -425,8 +425,46 @@ body {
   color: #9a948a; margin-top: 1px; transition: transform .2s ease, border-color .15s;
 }
 .fs-faq-icon.is-open { transform: rotate(45deg); border-color: var(--fs-accent); color: var(--fs-accent); }
-.fs-faq-answer { padding: 0 19px 19px 64px; animation: fsexpand .2s ease; }
-.fs-faq-atext { font-size: 13.5px; line-height: 1.72; color: #c4bfb5; margin: 0; }
+.fs-faq-answer { display: none; padding: 0 19px 18px; }
+.fs-faq-item.is-open .fs-faq-answer { display: block; animation: fsexpand .2s ease; }
+.fs-faq-atext { font-size: 13.5px; line-height: 1.72; color: #c4bfb5; margin: 0; white-space: pre-wrap; }
+
+/* ---- FAQ sidebar: sub-category nav ---- */
+.fs-faq-catnav { margin-top: 8px; }
+.fs-faq-catnav .fs-fac-name { font-weight: 700; }
+.fs-faq-subnav {
+  display: flex; align-items: center; gap: 8px; width: 100%; text-align: left;
+  appearance: none; border: 1px solid transparent; background: transparent; cursor: pointer;
+  font-family: inherit; color: #9a948a; font-size: 12.5px; font-weight: 500;
+  padding: 6px 11px 6px 30px; border-radius: 9px; transition: all .15s;
+}
+.fs-faq-subnav:hover { background: #1d1b18; color: #c4bdb1; }
+.fs-faq-subnav.is-active {
+  color: #f3efe8; background: #221f1a; font-weight: 600;
+  box-shadow: inset 2px 0 0 var(--fs-accent);
+}
+.fs-faq-subnav .fs-fac-name { flex: 1; }
+.fs-faq-subnav .fs-fac-count { font-family: 'IBM Plex Mono', monospace; font-size: 10px; color: #6f6a61; }
+
+/* ---- FAQ grouped content ---- */
+.fs-faq-sections { display: flex; flex-direction: column; gap: 28px; }
+.fs-faq-catblock { display: flex; flex-direction: column; gap: 16px; }
+.fs-faq-cathead {
+  display: flex; align-items: center; gap: 11px; font-size: 18px; font-weight: 700;
+  color: #f3efe8; margin: 4px 0 0;
+}
+.fs-faq-catdot { width: 11px; height: 11px; border-radius: 3px; transform: rotate(45deg); display: inline-block; }
+.fs-faq-subsection { display: flex; flex-direction: column; gap: 13px; }
+.fs-faq-sublabel {
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px; letter-spacing: 0.18em;
+  text-transform: uppercase; color: #bdb7ac; border-bottom: 1px solid #221f1a;
+  padding-bottom: 8px; margin-top: 8px;
+}
+.fs-faq-facgroup { display: flex; flex-direction: column; gap: 8px; }
+.fs-faq-fachead { display: flex; align-items: center; gap: 10px; padding: 4px 2px 2px; }
+.fs-faq-facicon { width: 24px; height: 24px; object-fit: contain; flex-shrink: 0; }
+.fs-faq-facname { font-size: 13px; font-weight: 600; color: #d8d2c8; letter-spacing: 0.01em; flex: 1; }
+.fs-faq-faccount { font-family: 'IBM Plex Mono', monospace; font-size: 10px; color: #6f6a61; }
 .fs-faq-tag {
   display: inline-block; margin-top: 13px; font-family: 'IBM Plex Mono', monospace;
   font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--fs-accent);


### PR DESCRIPTION
Follow-up on the merged FAQ/zoom work. Built on current `main`.

## FAQ (Field Manual)
- Preserve the full FAQ.json hierarchy: **Category › SubCategory › Faction**, each faction group showing its icon + question count.
- Sidebar lists each category **with its sub-categories nested** and individually selectable (counts per topic / sub-category).
- Opening a question no longer jumps to the top — answers live in the DOM and toggle via a local class flip (scroll preserved); answer text keeps source line breaks.
- Removed a duplicated sub-category heading; faction icon moved to the right and enlarged (104px).

## Lightbox / magnifier
- **Scroll** = zoom, **Shift+scroll** = resize the loupe (120–520px); on-screen hint pill + per-button tooltips.
- Top-right tool buttons (magnifier / full-screen / close) show styled hover tooltips.
- **Fill-screen** now upscales small scans to fill the viewport vertically instead of leaving large gaps.

## Navigation
- Clicking the logo returns to the default codex view (first expansion/faction, Combat) from anywhere, including the FAQ.

Verified in-browser across FAQ grouping/nav/search/scroll, magnifier gestures, tooltips, fill-screen, and logo navigation — no console errors beyond expected optional-`text.json` 404 probes.